### PR TITLE
Install django stubs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,8 @@ repos:
     rev: v1.15.0
     hooks:
       - id: mypy
+        additional_dependencies:
+          - django-stubs
   - repo: https://github.com/igorshubovych/markdownlint-cli
     rev: v0.44.0
     hooks:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,9 @@
 #    pip-compile --extra=dev --output-file=dev-requirements.txt pyproject.toml
 #
 asgiref==3.8.1
-    # via django
+    # via
+    #   django
+    #   django-stubs
 build==1.2.2.post1
     # via pip-tools
 cfgv==3.4.0
@@ -17,7 +19,14 @@ coverage[toml]==7.8.0
 distlib==0.3.9
     # via virtualenv
 django==5.2
+    # via
+    #   django-stubs
+    #   django-stubs-ext
+    #   procat (pyproject.toml)
+django-stubs[compatible-mypy]==5.2.0
     # via procat (pyproject.toml)
+django-stubs-ext==5.2.0
+    # via django-stubs
 filelock==3.18.0
     # via virtualenv
 identify==2.6.10
@@ -25,7 +34,9 @@ identify==2.6.10
 iniconfig==2.1.0
     # via pytest
 mypy==1.15.0
-    # via procat (pyproject.toml)
+    # via
+    #   django-stubs
+    #   procat (pyproject.toml)
 mypy-extensions==1.1.0
     # via mypy
 nodeenv==1.9.1
@@ -61,8 +72,13 @@ ruff==0.11.7
     # via procat (pyproject.toml)
 sqlparse==0.5.3
     # via django
+types-pyyaml==6.0.12.20250402
+    # via django-stubs
 typing-extensions==4.13.2
-    # via mypy
+    # via
+    #   django-stubs
+    #   django-stubs-ext
+    #   mypy
 virtualenv==20.30.0
     # via pre-commit
 wheel==0.45.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dev = [
     "pytest",
     "pytest-cov",
     "pytest-mock",
+    "django-stubs[compatible-mypy]"
 ]
 doc = [
     "mkdocs",
@@ -30,12 +31,16 @@ doc = [
 ]
 
 [tool.mypy]
+plugins = ["mypy_django_plugin.main"]
 disallow_any_explicit = true
 disallow_any_generics = true
 warn_unreachable = true
 warn_unused_ignores = true
 disallow_untyped_defs = true
 exclude = [".venv/", "docs/"]
+
+[tool.django-stubs]
+django_settings_module = "procat.settings"
 
 [[tool.mypy.overrides]]
 module = "tests.*"


### PR DESCRIPTION
# Description

- Django-stubs added to pyproject.toml to prevent mypy checks failing
- pip-compile run to update requirements files
- Django-stubs added to .pre-commit-config.yaml to prevent pre-commit hooks failing 

Fixes #46 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
