### PR TITLE
Update readme to include django and docker instructions

### DIFF
--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -18,3 +18,4 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
+          config_file: .linkspector.yml

--- a/.linkspector.yml
+++ b/.linkspector.yml
@@ -1,0 +1,5 @@
+dirs:
+  - ./
+useGitIgnore: true
+ignorePatterns:
+  - pattern: ^http://127.0.0.1:8000/.*$

--- a/README.md
+++ b/README.md
@@ -105,5 +105,5 @@ python package version specifiers, i.e. `"black<23"` or `"pip-tools!=6.12.2"`
 [pytest]: https://pytest.org/
 [GitHub Actions]: https://github.com/features/actions
 [pre-commit.ci]: https://pre-commit.ci
-[Docker]: [https://docs.docker.com/desktop/]
+[Docker]: https://docs.docker.com/desktop/
 [virtual environment]: https://docs.python.org/3/library/venv.html

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Ensure you have [Docker](https://docs.docker.com/desktop/) installed and simply 
 docker compose up
 ```
 
-The app will be available at <http://127.0.0.1:8000/> <!-- markdown-link-check-disable-line -->
+The app will be available at <http://127.0.0.1:8000/>
 
 ## Updating Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,18 @@
 # proCAT
 
-Project Charging and Analytics Tool
+A Django web app for hosting the Project Charging and Analytics Tool (ProCAT).
 
-This is a Python application that uses [`pip-tools`][pip-tools] for packaging and
-dependency management. It also provides [`pre-commit`][pre-commit] hooks (for
-[`ruff`][ruff] and [`mypy`][mypy]) and automated tests using [`pytest`][pytest] and
-[GitHub Actions]. Pre-commit hooks are automatically kept updated with a dedicated
-GitHub Action, this can be removed and replaced with [pre-commit.ci] if using a public
-repo. The package version is dynamically generated from the most recent git tag using
-[`setuptools-scm`][setuptools-scm].
+This Django project uses:
+
+- [`pip-tools`][pip-tools] for packaging and dependency management.
+- [`pre-commit`](https://pre-commit.com/) for various linting, formatting and static type checking.
+  - Pre-commit hooks are automatically kept updated with [pre-commit.ci](https://pre-commit.ci).
+- [`pytest`](https://pytest.org/) and [GitHub Actions](https://github.com/features/actions).
 
 [`pip-tools`][pip-tools] is chosen as a lightweight dependency manager that adheres to
 the [latest standards] using `pyproject.toml`.
 
-It was developed by the [Imperial College Research Software Engineering Team].
-
-## Usage
+## Installation
 
 To get started:
 
@@ -33,11 +30,10 @@ To get started:
    source .venv/bin/activate # with Powershell on Windows: `.venv\Scripts\Activate.ps1`
    ```
 
-1. Install development requirements and the package in editable mode:
+1. Install development requirements:
 
    ```bash
    pip install -r dev-requirements.txt
-   pip install -e .
    ```
 
 1. (Optionally) install tools for building documentation:
@@ -52,17 +48,41 @@ To get started:
    pre-commit install
    ```
 
-1. Run the main app:
+1. Run the web app:
 
    ```bash
-   python -m procat
+   python manage.py runserver
    ```
+
+   When running the webapp for the first time you may get a warning similar to:
+
+   `You have 19 unapplied migration(s). Your project may not work properly until you apply the migrations for app(s): admin, auth, contenttypes, main, sessions.`
+
+   If this is the case, stop your webapp (with CONTROL-C) and apply the migrations with:
+
+   ```bash
+   python manage.py migrate
+   ```
+
+   then restart it.
 
 1. Run the tests:
 
    ```bash
    pytest
    ```
+
+## Installation with Docker
+
+The app can be run within a Docker container and a `docker-compose.yml` file is provided to make this easy for development.
+
+Ensure you have [Docker](https://docs.docker.com/desktop/) installed and simply run:
+
+```bash
+docker compose up
+```
+
+The app will be available at <http://127.0.0.1:8000/> <!-- markdown-link-check-disable-line -->
 
 ## Updating Dependencies
 
@@ -83,31 +103,6 @@ To upgrade pinned versions, use the `--upgrade` flag with `pip-compile`.
 Versions can be restricted from updating within the `pyproject.toml` using standard
 python package version specifiers, i.e. `"black<23"` or `"pip-tools!=6.12.2"`
 
-## Customising
-
-All configuration can be customised to your preferences. The key places to make changes
-for this are:
-
-- The `pyproject.toml` file, where you can edit:
-  - The build system (change from setuptools to other packaging tools like [Hatch] or
-[flit]).
-  - The python version.
-  - The project dependencies. Extra optional dependencies can be added by adding another
-list under `[project.optional-dependencies]` (i.e. `doc = ["mkdocs"]`).
-  - The `mypy` and `pytest` configurations.
-- The `.pre-commit-config.yaml` for pre-commit settings.
-- The `.github` directory for all the CI configuration.
-
 [pip-tools]: https://pip-tools.readthedocs.io/en/stable/
-[pre-commit]: https://pre-commit.com/
-[ruff]: https://pypi.org/project/ruff/
-[mypy]: https://mypy.readthedocs.io/en/stable/
-[pytest]: https://pytest.org/
-[GitHub Actions]: https://github.com/features/actions
-[pre-commit.ci]: https://pre-commit.ci
-[setuptools-scm]: https://setuptools-scm.readthedocs.io/en/latest/
 [latest standards]: https://peps.python.org/pep-0621/
-[Imperial College Research Software Engineering Team]: https://www.imperial.ac.uk/admin-services/ict/self-service/research-support/rcs/service-offering/research-software-engineering/
 [virtual environment]: https://docs.python.org/3/library/venv.html
-[Hatch]: https://hatch.pypa.io/
-[flit]: https://flit.pypa.io/

--- a/README.md
+++ b/README.md
@@ -5,12 +5,9 @@ A Django web app for hosting the Project Charging and Analytics Tool (ProCAT).
 This Django project uses:
 
 - [`pip-tools`][pip-tools] for packaging and dependency management.
-- [`pre-commit`](https://pre-commit.com/) for various linting, formatting and static type checking.
-  - Pre-commit hooks are automatically kept updated with [pre-commit.ci](https://pre-commit.ci).
-- [`pytest`](https://pytest.org/) and [GitHub Actions](https://github.com/features/actions).
-
-[`pip-tools`][pip-tools] is chosen as a lightweight dependency manager that adheres to
-the [latest standards] using `pyproject.toml`.
+- [`pre-commit`][pre-commit] for various linting, formatting and static type checking.
+  - Pre-commit hooks are automatically kept updated with [pre-commit.ci][pre-commit.ci].
+- [`pytest`][pytest] and [GitHub Actions][GitHub Actions].
 
 ## Installation
 
@@ -76,7 +73,7 @@ To get started:
 
 The app can be run within a Docker container and a `docker-compose.yml` file is provided to make this easy for development.
 
-Ensure you have [Docker](https://docs.docker.com/desktop/) installed and simply run:
+Ensure you have [Docker][Docker] installed and simply run:
 
 ```bash
 docker compose up
@@ -104,5 +101,9 @@ Versions can be restricted from updating within the `pyproject.toml` using stand
 python package version specifiers, i.e. `"black<23"` or `"pip-tools!=6.12.2"`
 
 [pip-tools]: https://pip-tools.readthedocs.io/en/stable/
-[latest standards]: https://peps.python.org/pep-0621/
+[pre-commit]: https://pre-commit.com/
+[pytest]: https://pytest.org/
+[GitHub Actions]: https://github.com/features/actions
+[pre-commit.ci]: https://pre-commit.ci
+[Docker]: [https://docs.docker.com/desktop/]
 [virtual environment]: https://docs.python.org/3/library/venv.html


### PR DESCRIPTION
# Description

- Updated the README to include instructions on running the Django web app in a virtual environment and in a docker container (following PR provided as template in the issue). 
- Includes note regarding warning about unapplied migrations.

Fixes #43 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
