### PR TITLE
Add project detail page

### DIFF
--- a/main/tables.py
+++ b/main/tables.py
@@ -11,6 +11,8 @@ from .models import Project
 class ProjectTable(tables.Table):
     """Table for Project listing."""
 
+    name = tables.Column(linkify=("main:project_detail", {"pk": tables.A("pk")}))
+
     class Meta:
         """Meta class for the table."""
 

--- a/main/templates/main/project_detail.html
+++ b/main/templates/main/project_detail.html
@@ -1,0 +1,14 @@
+{% extends "main/base.html" %}
+{% load django_bootstrap5 %}
+
+{% block content %}
+  <h2>{{ project_name }}</h2>
+
+  <!-- Object details -->
+  <div class="row">
+    <div class="col">
+      <p>&nbsp;</p>
+      {% bootstrap_form form layout='horizontal' %}
+    </div>
+  </div>
+{% endblock content %}

--- a/main/urls.py
+++ b/main/urls.py
@@ -10,4 +10,7 @@ urlpatterns = [
     path("", views.index, name="index"),
     path("register/", views.RegistrationView.as_view(), name="auth_register"),
     path("projects/", views.ProjectsListView.as_view(), name="projects"),
+    path(
+        "projects/<slug:pk>/", views.ProjectDetailView.as_view(), name="project_detail"
+    ),
 ]

--- a/main/views.py
+++ b/main/views.py
@@ -1,10 +1,13 @@
 """Views for the main app."""
 
+from typing import Any
+
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.forms import ModelForm
 from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 from django.urls import reverse_lazy
-from django.views.generic import CreateView
+from django.views.generic import CreateView, UpdateView
 from django_filters.views import FilterView
 from django_tables2 import SingleTableMixin
 
@@ -35,3 +38,39 @@ class ProjectsListView(LoginRequiredMixin, SingleTableMixin, FilterView):
     table_class = tables.ProjectTable
     template_name = "main/projects.html"
     filterset_fields = ("nature", "department", "status", "charging")
+
+
+class ProjectDetailView(UpdateView):  # type: ignore [type-arg]
+    """Detail view based on a read-only form view.
+
+    While there is a generic Detail View, it is not rendered nicely easily as the
+    bootstrap theme needs to be applied on a field by field basis. So we use a form view
+    instead, which can easily be styled, and make the form read only.
+    """
+
+    model = models.Project
+    template_name = "main/project_detail.html"
+    fields = "__all__"
+
+    def get_form(self, form_class: Any | None = None) -> ModelForm:  # type: ignore
+        """Customize form to make it read-only.
+
+        Args:
+            form_class: The form class to use, if any.
+
+        Return:
+            A form associated to the model.
+        """
+        form = super().get_form(form_class)
+
+        for field in form.fields.keys():
+            form.fields[field].widget.attrs["disabled"] = True
+            form.fields[field].widget.attrs["readonly"] = True
+
+        return form
+
+    def get_context_data(self, **kwargs: Any) -> dict[str, Any]:  # type: ignore
+        """Add project name to the context, so it is easy to retrieve."""
+        context = super().get_context_data(**kwargs)
+        context["project_name"] = self.get_object().name
+        return context

--- a/main/views.py
+++ b/main/views.py
@@ -40,7 +40,7 @@ class ProjectsListView(LoginRequiredMixin, SingleTableMixin, FilterView):
     filterset_fields = ("nature", "department", "status", "charging")
 
 
-class ProjectDetailView(UpdateView):  # type: ignore [type-arg]
+class ProjectDetailView(LoginRequiredMixin, UpdateView):  # type: ignore [type-arg]
     """Detail view based on a read-only form view.
 
     While there is a generic Detail View, it is not rendered nicely easily as the
@@ -50,7 +50,7 @@ class ProjectDetailView(UpdateView):  # type: ignore [type-arg]
 
     model = models.Project
     template_name = "main/project_detail.html"
-    fields = "__all__"
+    fields = "__all__"  # type: ignore [assignment]
 
     def get_form(self, form_class: Any | None = None) -> ModelForm:  # type: ignore
         """Customize form to make it read-only.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,9 @@
 """Pytest configuration file."""
 
+from datetime import datetime, timedelta
+
 import pytest
+from django.test import Client
 
 
 @pytest.fixture
@@ -13,3 +16,34 @@ def user(django_user_model):
         password="1234",
         username="testuser",
     )
+
+
+@pytest.fixture
+def auth_client(user) -> Client:
+    """Return an authenticated client."""
+    client = Client()
+    client.force_login(user)
+    return client
+
+
+@pytest.fixture
+def department():
+    """Provides a default department object."""
+    from main import models
+
+    return models.Department.objects.get_or_create(name="ICT", faculty="Other")[0]
+
+
+@pytest.fixture
+def project(user, department):
+    """Provides a default project object."""
+    from main import models
+
+    return models.Project.objects.get_or_create(
+        name="ProCAT",
+        department=department,
+        lead=user,
+        start_date=datetime.now().date(),
+        end_date=datetime.now().date() + timedelta(days=42),
+        status="Active",
+    )[0]


### PR DESCRIPTION
# Description

Adds the project detail page and link it from the projects in the project list. Not much to see beyond the information already in the Admin, for now. 

While there is a generic Detail View, it is not rendered nicely easily as the bootstrap theme needs to be applied on a field by field basis. So we use a form view instead, which can easily be styled, and make the form read only.

https://github.com/user-attachments/assets/428b51e5-383b-4463-8b7d-982872f5cd41

Fixes #16
Fixes #11

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
