### PR TITLE
Add `user` filter to capacities list view

### DIFF
--- a/main/templates/main/capacities.html
+++ b/main/templates/main/capacities.html
@@ -1,6 +1,24 @@
 {% extends "main/base.html" %}
+{% load django_bootstrap5 %}
 {% load django_tables2 %}
+
 {% block content %}
   <h2>Capacities</h2>
+
+  <!-- Shortcut to access the capacities list url -->
+  {% url 'main:capacities' as capacities %}
+
+  <!-- Filter -->
+  <form action="" method="get" class="form form-inline">
+    <div class="row">
+      <div class="col-lg-5">{% bootstrap_form filter.form layout='horizontal' %}</div>
+      <div class="col-lg-5">
+        {% bootstrap_button 'Filter' %}
+        {% bootstrap_button 'Clear' button_type="link" button_class="btn-success" href=capacities %}
+      </div>
+    </div>
+  </form>
+
+  <!-- Table -->
   {% render_table table %}
 {% endblock content %}

--- a/main/views.py
+++ b/main/views.py
@@ -9,7 +9,7 @@ from django.shortcuts import render
 from django.urls import reverse_lazy
 from django.views.generic import CreateView, UpdateView
 from django_filters.views import FilterView
-from django_tables2 import SingleTableMixin, SingleTableView
+from django_tables2 import SingleTableMixin
 
 from . import forms, models, tables
 
@@ -40,12 +40,13 @@ class ProjectsListView(LoginRequiredMixin, SingleTableMixin, FilterView):
     filterset_fields = ("nature", "department", "status", "charging")
 
 
-class CapacitiesListView(LoginRequiredMixin, SingleTableView):
+class CapacitiesListView(LoginRequiredMixin, SingleTableMixin, FilterView):
     """View to display the list of capacities."""
 
     model = models.Capacity
     table_class = tables.CapacityTable
     template_name = "main/capacities.html"
+    filterset_fields = ("user",)
 
 
 class CustomBaseDetailView(LoginRequiredMixin, UpdateView):  # type: ignore [type-arg]


### PR DESCRIPTION
# Description

Adds a `user` filter to the capacities list view.

Fixes #59

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
