### PR TITLE
Fix project filtering in timeseries

### DIFF
--- a/main/timeseries.py
+++ b/main/timeseries.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from datetime import datetime
 
 import pandas as pd
-from django.db.models import F, Q, Window
+from django.db.models import F, Window
 from django.db.models.functions import Coalesce, Lead
 
 from . import models
@@ -61,7 +61,8 @@ def get_effort_timeseries(start_date: datetime, end_date: datetime) -> pd.Series
     # filter Projects to ensure dates exist and overlap with timeseries dates
     projects = list(
         models.Project.objects.filter(
-            Q(start_date__gte=start_date.date()) | Q(end_date__lt=end_date.date()),
+            start_date__lt=end_date.date(),
+            end_date__gte=start_date.date(),
             start_date__isnull=False,
             end_date__isnull=False,
         )

--- a/tests/main/test_timeseries.py
+++ b/tests/main/test_timeseries.py
@@ -25,12 +25,35 @@ def test_update_timeseries():
 
 
 @pytest.mark.django_db
-@pytest.mark.usefixtures("department", "user", "activity_code")
-def test_get_effort_timeseries():
+@pytest.mark.parametrize(
+    ["start_date", "end_date", "plot_start_date", "plot_end_date"],
+    [
+        [
+            datetime.now().date() + timedelta(7),
+            datetime.now().date() + timedelta(14),
+            datetime.now(),
+            datetime.now() + timedelta(21),
+        ],
+        [
+            datetime.now().date(),
+            datetime.now().date() + timedelta(21),
+            datetime.now() + timedelta(7),
+            datetime.now() + timedelta(14),
+        ],
+    ],
+)
+def test_get_effort_timeseries(
+    department,
+    user,
+    activity_code,
+    start_date,
+    end_date,
+    plot_start_date,
+    plot_end_date,
+):
     """Test the get_effort_timeseries function."""
     from main import models, timeseries
 
-    plot_start_date, plot_end_date = datetime.now(), datetime.now() + timedelta(28)
     department = models.Department.objects.get(name="ICT")
     user = models.User.objects.get(username="testuser")
     project = models.Project.objects.create(
@@ -38,8 +61,8 @@ def test_get_effort_timeseries():
         department=department,
         lead=user,
         status="Active",
-        start_date=datetime.now().date() + timedelta(7),
-        end_date=datetime.now().date() + timedelta(14),
+        start_date=start_date,
+        end_date=end_date,
     )
 
     activity_code = models.ActivityCode.objects.get(code="1234")


### PR DESCRIPTION
# Description

- Fix error in `timeseries.py` where projects are not filtered correctly (where the project dates are checked for overlap with plotting dates)
- Updated test `test_get_effort_timeseries` to catch where the original code would fail

Fixes #187 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
