### PR TITLE
Fix error in test_get_effort_timeseries

### DIFF
--- a/tests/main/test_timeseries.py
+++ b/tests/main/test_timeseries.py
@@ -26,28 +26,25 @@ def test_update_timeseries():
 
 @pytest.mark.django_db
 @pytest.mark.parametrize(
-    ["start_date", "end_date", "plot_start_date", "plot_end_date", "n_days"],
+    ["start_date", "end_date", "plot_start_date", "plot_end_date"],
     [
         [
             datetime.now().date() + timedelta(7),
             datetime.now().date() + timedelta(14),
             datetime.now(),
             datetime.now() + timedelta(21),
-            5,
         ],
         [
             datetime.now().date(),
             datetime.now().date() + timedelta(21),
             datetime.now() + timedelta(7),
             datetime.now() + timedelta(14),
-            5,
         ],
         [
             datetime.now().date(),
             datetime.now().date() + timedelta(20),
             datetime.now() + timedelta(4),
             datetime.now() + timedelta(30),
-            11,
         ],
     ],
 )
@@ -59,7 +56,6 @@ def test_get_effort_timeseries(
     end_date,
     plot_start_date,
     plot_end_date,
-    n_days,
 ):
     """Test the get_effort_timeseries function."""
     from main import models, timeseries
@@ -88,6 +84,11 @@ def test_get_effort_timeseries(
     effort = funding.budget / funding.daily_rate
     effort_per_day = effort / project.total_working_days
     n_entries = ts.value_counts()[effort_per_day]
+
+    # get intersecting dates
+    project_days = pd.bdate_range(start_date, end_date, inclusive="left")
+    plot_days = pd.bdate_range(plot_start_date, plot_end_date, inclusive="left")
+    n_days = len(project_days.intersection(plot_days))
     assert n_entries == n_days
 
 


### PR DESCRIPTION
# Description

I made an error in one of the parametrized tests for `test_get_effort_timeseries` (it will fail depending on the day). I have changed the test so the number of intersecting days between the project and the plot are calculated rather than hard-coded. 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
