### PR TITLE
Update funding effort left

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -591,7 +591,6 @@ class MonthlyCharge(models.Model):
         null=False,
         blank=False,
         help_text="The funding source to be used for the charge.",
-        related_name="monthly_charge",
     )
 
     amount = models.DecimalField(

--- a/main/models.py
+++ b/main/models.py
@@ -626,13 +626,12 @@ class MonthlyCharge(models.Model):
     def clean(self) -> None:
         """Ensure the charge has valid funding attached and description if Manual."""
         super().clean()
-
-        if not self.funding.expiry_date or not self.funding.funding_left:
-            raise ValidationError("Funding source must have expiry date and amount.")
+        if not self.funding.expiry_date:
+            raise ValidationError("Funding source must have an expiry date.")
 
         if (
             self.date > self.funding.expiry_date
-            or self.amount > self.funding.funding_left
+            or self.funding.funding_left < 0  # After deducting charge amount
         ):
             raise ValidationError(
                 "Monthly charge must not exceed the funding date or amount."

--- a/main/models.py
+++ b/main/models.py
@@ -239,10 +239,8 @@ class Project(models.Model):
         Returns:
             The percentage of effort left, or None if there is no funding information.
         """
-        if self.total_effort:
-            left = sum([funding.effort_left for funding in self.funding_source.all()])
-            return round(left / self.total_effort * 100, 1)
-
+        if left := self.days_left:
+            return left[1]
         return None
 
     @property
@@ -263,9 +261,9 @@ class Project(models.Model):
             start_date = end_date.replace(day=1)
             additional_days = get_actual_chargeable_days(self, start_date, end_date)[0]
             if additional_days:
-                left -= round(additional_days)
+                left -= additional_days
 
-            return left, round(left / self.total_effort * 100, 1)
+            return round(left), round(left / self.total_effort * 100, 1)
 
         return None
 
@@ -505,13 +503,13 @@ class Funding(models.Model):
         return self.budget
 
     @property
-    def effort_left(self) -> int:
+    def effort_left(self) -> float:
         """Provide the effort left in days.
 
         Returns:
             The number of days worth of effort left.
         """
-        return round(self.funding_left / self.daily_rate)
+        return float(self.funding_left / self.daily_rate)
 
     @property
     def monthly_pro_rata_charge(self) -> float | None:

--- a/main/report.py
+++ b/main/report.py
@@ -34,7 +34,6 @@ def get_actual_chargeable_days(
         project=project,
         start_time__gte=start_time,
         start_time__lt=end_time,
-        monthly_charge__isnull=True,
     )
     pks = list(time_entries.values_list("pk", flat=True))
 

--- a/main/report.py
+++ b/main/report.py
@@ -34,6 +34,7 @@ def get_actual_chargeable_days(
         project=project,
         start_time__gte=start_time,
         start_time__lt=end_time,
+        monthly_charge__isnull=True,
     )
     pks = list(time_entries.values_list("pk", flat=True))
 

--- a/tests/main/test_models.py
+++ b/tests/main/test_models.py
@@ -615,7 +615,7 @@ class TestMonthlyCharge:
         )
         with pytest.raises(
             ValidationError,
-            match="Funding source must have expiry date and amount.",
+            match="Funding source must have an expiry date.",
         ):
             monthly_charge.clean()
 
@@ -637,17 +637,18 @@ class TestMonthlyCharge:
         ):
             monthly_charge.clean()
 
-    @pytest.mark.usefixtures("project", "funding")
+    @pytest.mark.django_db
     def test_clean_invalid_funding(self, project, funding):
         """Test the model validation for the amount field."""
         from main import models
 
-        monthly_charge = models.MonthlyCharge(
+        monthly_charge = models.MonthlyCharge.objects.create(
             project=project,
             funding=funding,
             date=funding.expiry_date - timedelta(1),
-            amount=funding.funding_left + 1,  # invalid funding
+            amount=funding.funding_left + 1,  # Invalid funding
         )
+        funding.refresh_from_db()  # Update funding object
 
         with pytest.raises(
             ValidationError,

--- a/tests/main/test_models.py
+++ b/tests/main/test_models.py
@@ -136,6 +136,34 @@ class TestProject:
         assert project.total_effort == total_effort
 
     @pytest.mark.django_db
+    def test_percent_effort_left(self, project, analysis_code):
+        """Test the percent_effort_left method."""
+        from main import models
+
+        # Check when there is no Funding objrect
+        assert project.percent_effort_left is None
+
+        # Create Funding object and Monthly Charge
+        funding = models.Funding.objects.create(
+            project=project,
+            source="External",
+            funding_body="Funding body",
+            cost_centre="centre",
+            activity="G12345",
+            analysis_code=analysis_code,
+            expiry_date=datetime.now().date() + timedelta(days=42),
+            budget=1000.00,
+            daily_rate=200.00,
+        )
+        models.MonthlyCharge.objects.create(
+            date=datetime.today().date(),
+            project=project,
+            funding=funding,
+            amount=100.00,
+        )
+        assert project.days_left[1] == project.percent_effort_left
+
+    @pytest.mark.django_db
     def test_days_left(self, user, department, analysis_code):
         """Test the days_left method."""
         from main import models

--- a/tests/main/test_models.py
+++ b/tests/main/test_models.py
@@ -199,7 +199,7 @@ class TestProject:
         # Check days_left when there are no extra time entries
         total_effort = funding_A.effort + funding_B.effort
         left = funding_A.effort_left + funding_B.effort_left
-        days_left = left, round(left / total_effort * 100, 1)
+        days_left = round(left), round(left / total_effort * 100, 1)
         assert project.days_left == days_left
 
         # Create a time entry object for yesterday
@@ -213,8 +213,8 @@ class TestProject:
         )  # 3.5 hours total (0.5 days)
 
         # Check days_left has been updated
-        left -= round(0.5)
-        days_left = left, round(left / total_effort * 100, 1)
+        left -= 0.5
+        days_left = round(left), round(left / total_effort * 100, 1)
         assert project.days_left == days_left
 
     @pytest.mark.parametrize(
@@ -445,7 +445,7 @@ class TestFunding:
 
         # No monthly charges
         funding.refresh_from_db()
-        assert funding.effort_left == funding.effort
+        assert round(funding.effort_left) == funding.effort
 
         # Check when monthly charge created
         charge_date = funding.expiry_date - timedelta(days=5)
@@ -453,7 +453,7 @@ class TestFunding:
             project=project, funding=funding, amount=100.00, date=charge_date
         )
         monthly_charge.refresh_from_db()
-        effort_left = round(
+        effort_left = float(
             (funding.budget - monthly_charge.amount) / funding.daily_rate
         )
         assert funding.effort_left == effort_left

--- a/tests/main/test_report.py
+++ b/tests/main/test_report.py
@@ -211,19 +211,19 @@ def test_create_actual_monthly_charges_validate_effort_left(
         project=project,
         start_time=datetime(2025, 6, 1, 9, 0),
         end_time=datetime(2025, 6, 1, 16, 0),
-    )
+    )  # 7 hours total
     models.TimeEntry.objects.create(
         user=user,
         project=project,
-        start_time=datetime(2025, 6, 10, 1, 0),
-        end_time=datetime(2025, 6, 10, 17, 45),
-    )
+        start_time=datetime(2025, 6, 10, 8, 0),
+        end_time=datetime(2025, 6, 10, 19, 0),
+    )  # 11 hours total
     models.TimeEntry.objects.create(
         user=user,
         project=project,
         start_time=datetime(2025, 6, 15, 12, 0),
-        end_time=datetime(2025, 6, 15, 15, 50),
-    )
+        end_time=datetime(2025, 6, 15, 22, 30),
+    )  # 10.5 hours total
 
     # Check that the time entries exceed the funding
     with pytest.raises(
@@ -304,8 +304,8 @@ def test_create_actual_monthly_charges(department, user, analysis_code):
 
     # Check monthly charges created against funding A (total) and funding B
     charges = models.MonthlyCharge.objects.all().filter(date=start_date)
-    assert round(float(funding_A.daily_rate) * funding_A_days, 2) == charges[0].amount
-    assert round(float(funding_B.daily_rate) * funding_B_days, 2) == charges[1].amount
+    assert round(funding_A.daily_rate * funding_A_days, 2) == float(charges[0].amount)
+    assert round(funding_B.daily_rate * funding_B_days, 2) == float(charges[1].amount)
 
     # Check monthly charge has been added to time entries
     assert charges[0] in time_entry_A.monthly_charge.all()


### PR DESCRIPTION
# Description

This PR updates the logic behind `effort_left` in the Funding model.

The changes are as follows:
- `Funding.funding_left` - returns budget - (all monthly charge amounts)
- `Funding.effort_left` - returns funding_left / daily_rate (rounded to nearest int)
- `Project.days_left` - returns (sum of effort left for all funding sources) - (total chargeable days after aggregating all time entries between 1st of the current month and today) 
- Tests written for model properties and updated in report.py (where they were pending the above updates)

Note:

- One problem I noticed during testing was in the clean method for monthly charge. The clean method originally checks that the amount to be charged doesn't exceed `funding_left`. However, when this is run in report.py, the amount has already been deducted from `funding_left`, so an error is raised. I have changed it so that it checks that `funding_left` is at least 0, (so we are not left with negative funds after deducting the monthly charge) -- does this make sense?

Fixes #181 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
