### PR TITLE
Charges bar plot

### DIFF
--- a/main/plots.py
+++ b/main/plots.py
@@ -185,8 +185,7 @@ def html_components_from_plot(
             f"{prefix}_div": div,
         }
 
-    else:
-        return {
-            "script": script,
-            "div": div,
-        }
+    return {
+        "script": script,
+        "div": div,
+    }

--- a/main/plots.py
+++ b/main/plots.py
@@ -12,33 +12,33 @@ from . import timeseries
 from .utils import get_month_dates_for_previous_year
 
 
-def create_bar_plot(title: str, dates: list[str], values: list[float]) -> figure:
+def create_bar_plot(title: str, months: list[str], values: list[float]) -> figure:
     """Creates a bar plot with dates versus values.
 
     Args:
         title: plot title
-        dates: a list of dates to display on the x-axis
+        months: a list of months to display on the x-axis
         values: a list of total charge values for the bar height indicate on the y-axis
 
     Returns:
         Bokeh figure for the bar chart.
     """
-    source = ColumnDataSource(data=dict(dates=dates, values=values))
+    source = ColumnDataSource(data=dict(months=months, values=values))
     plot = figure(
-        x_range=dates,  # type: ignore[arg-type]
+        x_range=months,  # type: ignore[arg-type]
         title=title,
         width=1000,
         height=500,
         background_fill_color="#efefef",
     )
     plot.yaxis.axis_label = "Total charge (£)"
-    plot.xaxis.axis_label = "Date"
-    plot.vbar(x="dates", top="values", width=0.5, source=source)
+    plot.xaxis.axis_label = "Month-Year"
+    plot.vbar(x="months", top="values", width=0.5, source=source)
 
     # Add basic tooltips to show monthly totals
     hover = HoverTool()
     hover.tooltips = [
-        ("Month", "@dates"),
+        ("Month", "@months"),
         ("Total", "£@values"),
     ]
     plot.add_tools(hover)
@@ -156,13 +156,13 @@ def create_cost_recovery_plots() -> tuple[figure, figure]:
     )
 
     # Create bar plot for monthly charges
-    chart_dates = [f"{date[0].strftime('%b')} {date[0].year}" for date in dates]
+    chart_months = [f"{date[0].strftime('%b')} {date[0].year}" for date in dates]
     bar_plot = create_bar_plot(
         title=(
             f"Monthly charges from {start_date.strftime('%B')} {start_date.year} to "
             f"{end_date.strftime('%B')} {end_date.year}"
         ),
-        dates=chart_dates,
+        months=chart_months,
         values=monthly_totals,
     )
 

--- a/main/plots.py
+++ b/main/plots.py
@@ -3,7 +3,7 @@
 from datetime import datetime, time
 
 import pandas as pd
-from bokeh.models import ColumnDataSource
+from bokeh.models import ColumnDataSource, HoverTool
 from bokeh.plotting import figure
 
 from . import timeseries
@@ -33,12 +33,12 @@ def calculate_capacity_planning_traces(
     return source
 
 
-def calculate_cost_recovery_traces() -> ColumnDataSource:
+def calculate_cost_recovery_traces() -> tuple[ColumnDataSource, ColumnDataSource]:
     """Get data from the Django database for the capacity and cost recovery traces.
 
     Returns:
-        Bokeh ColumnDataSource object containing the Monthly charge and Capacity
-        timeseries columns.
+        Tuple of ColumnDataSources for the Cost Recovery timeseries and total monthly
+            charges data.
     """
     dates = get_month_dates_for_previous_year()
 
@@ -49,14 +49,52 @@ def calculate_cost_recovery_traces() -> ColumnDataSource:
         start_date=start_date, end_date=end_date
     )
 
-    # Create cost recovery timeseries
-    cost_recovery_timeseries = timeseries.get_cost_recovery_timeseries(dates)
+    cost_recovery_timeseries, monthly_totals = timeseries.get_cost_recovery_timeseries(
+        dates
+    )
+
     timeseries_df = pd.DataFrame(
         {"Capacity": capacity_timeseries, "Cost recovery": cost_recovery_timeseries}
     )
     timeseries_df.reset_index(inplace=True)
-    source = ColumnDataSource(timeseries_df)
-    return source
+    timeseries_source = ColumnDataSource(timeseries_df)
+
+    # Create bar plot data source
+    chart_dates = [f"{date[0].strftime('%b')} {date[0].year}" for date in dates]
+    bar_source = ColumnDataSource(data=dict(dates=chart_dates, values=monthly_totals))
+
+    return timeseries_source, bar_source
+
+
+def create_bar_plot(source: ColumnDataSource, title: str) -> figure:
+    """Creates a bar plot.
+
+    Args:
+        source: Bokeh ColumnDataSource object containing data.
+        title: plot title
+
+    Returns:
+        Bokeh figure for the bar chart.
+    """
+    plot = figure(
+        x_range=list(source.data["dates"]),
+        title=title,
+        width=1000,
+        height=500,
+        background_fill_color="#efefef",
+    )
+    plot.yaxis.axis_label = "Total charge (£)"
+    plot.xaxis.axis_label = "Date"
+    plot.vbar(x="dates", top="values", width=0.5, source=source)
+
+    # Add basic tooltips to show monthly totals
+    hover = HoverTool()
+    hover.tooltips = [
+        ("Month", "@dates"),
+        ("Total", "@values"),
+    ]
+    plot.add_tools(hover)
+    return plot
 
 
 def create_timeseries_plot(
@@ -126,15 +164,16 @@ def create_capacity_planning_plot(start_date: datetime, end_date: datetime) -> f
     return plot
 
 
-def create_cost_recovery_plot() -> figure:
+def create_cost_recovery_plots() -> tuple[figure, figure]:
     """Creates the cost recovery plot for the last year.
 
     Provides an overview of team capacity over the past year and the project charging.
 
     Returns:
-        Bokeh figure containing cost recovery data.
+        Tuple of Bokeh figures containing cost recovery data timeseries data and
+            monthly charges for the past year.
     """
-    source = calculate_cost_recovery_traces()
+    timeseries_source, bar_source = calculate_cost_recovery_traces()
 
     # provide info needed to plot as dictionary for each trace
     traces = [
@@ -145,10 +184,12 @@ def create_cost_recovery_plot() -> figure:
         },
         {"col_name": "Capacity", "colour": "navy", "legend_label": "Capacity"},
     ]
-    plot = create_timeseries_plot(
-        source=source,
+    timeseries_plot = create_timeseries_plot(
+        source=timeseries_source,
         title="Team capacity and project charging for the past year",
         traces=traces,
     )
 
-    return plot
+    bar_plot = create_bar_plot(bar_source, "Monthly charges for the past year")
+
+    return timeseries_plot, bar_plot

--- a/main/plots.py
+++ b/main/plots.py
@@ -18,7 +18,7 @@ def create_bar_plot(title: str, dates: list[str], values: list[float]) -> figure
     Args:
         title: plot title
         dates: a list of dates to display on the x-axis
-        values: a list of values for the bars
+        values: a list of total charge values for the bar height indicate on the y-axis
 
     Returns:
         Bokeh figure for the bar chart.
@@ -148,13 +148,20 @@ def create_cost_recovery_plots() -> tuple[figure, figure]:
         {"timeseries": capacity_timeseries, "colour": "navy", "label": "Capacity"},
     ]
     timeseries_plot = create_timeseries_plot(
-        title="Team capacity and project charging for the past year", traces=traces
+        title=(
+            f"Team capacity and project charging from {start_date.strftime('%B')} "
+            f"{start_date.year} to {end_date.strftime('%B')} {end_date.year}"
+        ),
+        traces=traces,
     )
 
     # Create bar plot for monthly charges
     chart_dates = [f"{date[0].strftime('%b')} {date[0].year}" for date in dates]
     bar_plot = create_bar_plot(
-        title="Monthly charges for the past year",
+        title=(
+            f"Monthly charges from {start_date.strftime('%B')} {start_date.year} to "
+            f"{end_date.strftime('%B')} {end_date.year}"
+        ),
         dates=chart_dates,
         values=monthly_totals,
     )

--- a/main/templates/main/cost_recovery.html
+++ b/main/templates/main/cost_recovery.html
@@ -19,8 +19,12 @@
 
   <br>
 
-  <h2>Cost recovery plot</h2>
-  {{ script | safe }}
-  {{ div | safe }}
+  <h2>Cost recovery plots</h2>
+
+  {{ timeseries_script | safe }}
+  {{ timeseries_div | safe }}
+
+  {{ bar_script | safe }}
+  {{ bar_div | safe }}
 
 {% endblock content %}

--- a/main/views.py
+++ b/main/views.py
@@ -164,9 +164,17 @@ class CostRecoveryView(LoginRequiredMixin, FormView):  # type: ignore [type-arg]
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:  # type: ignore
         """Add HTML components and Bokeh version to the context."""
         context = super().get_context_data(**kwargs)
-        plot = plots.create_cost_recovery_plot()
-        script, div = components(plot)
-        context["script"] = script
-        context["div"] = div
+        timeseries_plot, bar_plot = plots.create_cost_recovery_plots()
+
+        # Add timeseries plot to view
+        timeseries_script, timeseries_div = components(timeseries_plot)
+        context["timeseries_script"] = timeseries_script
+        context["timeseries_div"] = timeseries_div
+
+        # Add monthly charges bar plot to view
+        bar_script, bar_div = components(bar_plot)
+        context["bar_script"] = bar_script
+        context["bar_div"] = bar_div
+
         context["bokeh_version"] = bokeh.__version__
         return context

--- a/main/views.py
+++ b/main/views.py
@@ -4,7 +4,6 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import bokeh
-from bokeh.embed import components
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.forms import Form, ModelForm
 from django.http import HttpRequest, HttpResponse
@@ -141,9 +140,7 @@ class CapacityPlanningView(LoginRequiredMixin, TemplateView):
         plot = plots.create_capacity_planning_plot(
             datetime.now(), datetime.now() + timedelta(365)
         )
-        script, div = components(plot)
-        context["script"] = script
-        context["div"] = div
+        context.update(plots.html_components_from_plot(plot))
         context["bokeh_version"] = bokeh.__version__
         return context
 
@@ -165,16 +162,7 @@ class CostRecoveryView(LoginRequiredMixin, FormView):  # type: ignore [type-arg]
         """Add HTML components and Bokeh version to the context."""
         context = super().get_context_data(**kwargs)
         timeseries_plot, bar_plot = plots.create_cost_recovery_plots()
-
-        # Add timeseries plot to view
-        timeseries_script, timeseries_div = components(timeseries_plot)
-        context["timeseries_script"] = timeseries_script
-        context["timeseries_div"] = timeseries_div
-
-        # Add monthly charges bar plot to view
-        bar_script, bar_div = components(bar_plot)
-        context["bar_script"] = bar_script
-        context["bar_div"] = bar_div
-
+        context.update(plots.html_components_from_plot(timeseries_plot, "timeseries"))
+        context.update(plots.html_components_from_plot(bar_plot, "bar"))
         context["bokeh_version"] = bokeh.__version__
         return context

--- a/tests/main/test_plots.py
+++ b/tests/main/test_plots.py
@@ -6,21 +6,6 @@ import pytest
 
 
 @pytest.mark.usefixtures("project", "funding", "capacity")
-def test_calculate_capacity_planning_traces():
-    """Test function to get plotting data as dataframe."""
-    from bokeh.models import ColumnDataSource
-
-    from main import plots
-
-    source = plots.calculate_capacity_planning_traces(
-        datetime.now(), datetime.now() + timedelta(365)
-    )
-    assert isinstance(source, ColumnDataSource)
-    assert "Effort" in source.data
-    assert "Capacity" in source.data
-
-
-@pytest.mark.usefixtures("project", "funding", "capacity")
 def test_create_capacity_planning_plot():
     """Test function to create the capacity planning plot."""
     from bokeh.plotting import figure
@@ -44,6 +29,7 @@ def test_create_capacity_planning_plot():
 
 def test_create_cost_recovery_plot(project, funding):
     """Test function to create the cost recovery plot."""
+    from bokeh.models import HoverTool
     from bokeh.plotting import figure
 
     from main import models, plots
@@ -55,14 +41,25 @@ def test_create_cost_recovery_plot(project, funding):
         amount=100.00,
         date=datetime.today().date() - timedelta(100),
     )
-    plot = plots.create_cost_recovery_plot()
-    assert isinstance(plot, figure)
+    ts_plot, bar_plot = plots.create_cost_recovery_plots()
 
-    title = "Team capacity and project charging for the past year"
-    assert plot.title.text == title
-    assert plot.yaxis.axis_label == "Value"
-    assert plot.xaxis.axis_label == "Date"
+    # Test timeseries plot
+    assert isinstance(ts_plot, figure)
 
-    legend_items = [item.label.value for item in plot.legend.items]
-    assert "Capacity used" in legend_items
-    assert "Capacity" in legend_items
+    ts_title = "Team capacity and project charging for the past year"
+    assert ts_plot.title.text == ts_title
+    assert ts_plot.yaxis.axis_label == "Value"
+    assert ts_plot.xaxis.axis_label == "Date"
+
+    ts_legend_items = [item.label.value for item in ts_plot.legend.items]
+    assert "Capacity used" in ts_legend_items
+    assert "Capacity" in ts_legend_items
+
+    # Test bar plot
+    assert isinstance(bar_plot, figure)
+
+    bar_title = "Monthly charges for the past year"
+    assert bar_plot.title.text == bar_title
+    assert bar_plot.yaxis.axis_label == "Total charge (£)"
+    assert bar_plot.xaxis.axis_label == "Date"
+    assert isinstance(bar_plot.tools[-1], HoverTool)

--- a/tests/main/test_plots.py
+++ b/tests/main/test_plots.py
@@ -71,5 +71,5 @@ def test_create_cost_recovery_plot(project, funding):
     )
     assert bar_plot.title.text == bar_title
     assert bar_plot.yaxis.axis_label == "Total charge (£)"
-    assert bar_plot.xaxis.axis_label == "Date"
+    assert bar_plot.xaxis.axis_label == "Month-Year"
     assert isinstance(bar_plot.tools[-1], HoverTool)

--- a/tests/main/test_plots.py
+++ b/tests/main/test_plots.py
@@ -46,7 +46,14 @@ def test_create_cost_recovery_plot(project, funding):
     # Test timeseries plot
     assert isinstance(ts_plot, figure)
 
-    ts_title = "Team capacity and project charging for the past year"
+    first_of_month = datetime.today().date().replace(day=1)
+    end_date = (first_of_month - timedelta(days=1)).replace(day=1)
+    start_date = first_of_month.replace(year=end_date.year - 1)
+
+    ts_title = (
+        f"Team capacity and project charging from {start_date.strftime('%B')} "
+        f"{start_date.year} to {end_date.strftime('%B')} {end_date.year}"
+    )
     assert ts_plot.title.text == ts_title
     assert ts_plot.yaxis.axis_label == "Value"
     assert ts_plot.xaxis.axis_label == "Date"
@@ -58,7 +65,10 @@ def test_create_cost_recovery_plot(project, funding):
     # Test bar plot
     assert isinstance(bar_plot, figure)
 
-    bar_title = "Monthly charges for the past year"
+    bar_title = (
+        f"Monthly charges from {start_date.strftime('%B')} {start_date.year} "
+        f"to {end_date.strftime('%B')} {end_date.year}"
+    )
     assert bar_plot.title.text == bar_title
     assert bar_plot.yaxis.axis_label == "Total charge (£)"
     assert bar_plot.xaxis.axis_label == "Date"

--- a/tests/main/test_timeseries.py
+++ b/tests/main/test_timeseries.py
@@ -173,7 +173,7 @@ def test_get_cost_recovery_timeseries(department, user, analysis_code):
 
     # Create cost recovery timeseries
     dates = utils.get_month_dates_for_previous_year()
-    ts = timeseries.get_cost_recovery_timeseries(dates)
+    ts, charge_totals = timeseries.get_cost_recovery_timeseries(dates)
 
     # Get expected value
     n_days = len(
@@ -185,6 +185,7 @@ def test_get_cost_recovery_timeseries(department, user, analysis_code):
     )
     assert isinstance(ts, pd.Series)
     assert ts.value_counts()[expected_value] == n_days
+    assert charge_totals[-1] == 600.00
 
 
 @pytest.mark.django_db
@@ -262,7 +263,7 @@ def test_get_cost_recovery_timeseries_equal_to_num_people(
 
     # Create cost recovery timeseries
     dates = utils.get_month_dates_for_previous_year()
-    ts = timeseries.get_cost_recovery_timeseries(dates)
+    ts = timeseries.get_cost_recovery_timeseries(dates)[0]
 
     # Expected value for 2 individuals working full-time on projects would be 2.0
     assert ts.value_counts()[2.0] == n_working_days

--- a/tests/main/test_views.py
+++ b/tests/main/test_views.py
@@ -146,8 +146,10 @@ class TestCostRecoveryView(LoginRequiredMixin, TemplateOkMixin):
         endpoint = reverse("main:cost_recovery")
         response = auth_client.get(endpoint)
         assert response.status_code == HTTPStatus.OK
-        assert "<script" in response.context["script"]
-        assert "<div" in response.context["div"]
+        assert "<script" in response.context["timeseries_script"]
+        assert "<div" in response.context["timeseries_div"]
+        assert "<script" in response.context["bar_script"]
+        assert "<div" in response.context["bar_div"]
         assert response.context["bokeh_version"] == bokeh.__version__
 
     def test_form_valid(self, user):


### PR DESCRIPTION
# Description

- Adds a basic bar plot to the cost recovery page which shows the total monthly charges for each month in the past year
  - Just displayed below the timeseries plot right now -- layout could be improved?
  - Has a basic tooltips to show exact monthly charge amount on hover

https://github.com/user-attachments/assets/d63a1999-593e-4ac9-873d-507e85fad50c

- Refactors some of the plotting functions (and updates tests accordingly) as the multiple functions was getting a bit confusing
  - E.g. adds a function to create html components from plot to be added to the context (to avoid repeated code)
  - Remove separate functions that get ColumnDataSource from timeseries, this is now done in create_XXX_plot

Fixes #225 

Note:
- Probably the layout can definitely be improved? Like making the plots smaller, displaying them side-by-side? Suggestions very welcome!

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
