### PR TITLE
Ensure time entries not duplicated in actual_chargeable_days calculation and update days_left calculation

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -1,6 +1,6 @@
 """Models module for main app."""
 
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 from django.contrib.auth.models import AbstractUser
@@ -256,9 +256,10 @@ class Project(models.Model):
         if self.total_effort:
             left = sum([funding.effort_left for funding in self.funding_source.all()])
 
-            # subtract days logged for the month so far
+            # Subtract additional unassigned time entries from the start of last month
+            # until the current date
             end_date = datetime.today().date()
-            start_date = end_date.replace(day=1)
+            start_date = (end_date.replace(day=1) - timedelta(days=1)).replace(day=1)
             additional_days = get_actual_chargeable_days(self, start_date, end_date)[0]
             if additional_days:
                 left -= additional_days

--- a/main/report.py
+++ b/main/report.py
@@ -34,6 +34,7 @@ def get_actual_chargeable_days(
         project=project,
         start_time__gte=start_time,
         start_time__lt=end_time,
+        monthly_charge__isnull=True,
     )
     pks = list(time_entries.values_list("pk", flat=True))
 

--- a/tests/main/test_report.py
+++ b/tests/main/test_report.py
@@ -9,7 +9,7 @@ from django.core.exceptions import ValidationError
 
 
 @pytest.mark.django_db
-def test_get_actual_chargeable_days(user, project):
+def test_get_actual_chargeable_days(user, project, funding):
     """Test the get_actual_chargeable_days function."""
     from main import models, report
 
@@ -35,6 +35,21 @@ def test_get_actual_chargeable_days(user, project):
         start_time=datetime(2025, 6, 4, 10, 0),
         end_time=datetime(2025, 6, 4, 14, 0),
     )  # 4 hours total
+
+    # Add time entry with monthly charge assigned (should not be counted)
+    time_entry_C = models.TimeEntry.objects.create(
+        user=user,
+        project=project,
+        start_time=datetime(2025, 6, 4, 12, 0),
+        end_time=datetime(2025, 6, 4, 17, 0),
+    )  # 5 hours total
+    charge = models.MonthlyCharge.objects.create(
+        date=start_date,
+        project=project,
+        funding=funding,
+        amount=10.00,
+    )
+    time_entry_C.monthly_charge.add(charge)
 
     pks = [time_entry_A.pk, time_entry_B.pk]
     expected_result = (1, pks)  # 7 hours total = 1 day


### PR DESCRIPTION
# Description

Ensures that time entries used in `get_actual_chargeable_days` do not have a monthly charge assigned already (this could happen if a charges report has already been generated for the month so far), so they are not duplicated in the `project.days_left` calculation.

`Project.days_left` has also been updated in response to a failing test

- The whole calculation is as follows (new change in bold)
  - `Funding.effort_left` provides the effort left in days for each funding source (this is calculated based on created Monthly Charge objects)
  - `Project.days_left` aggregates `effort_left` for each funding source, and then deducts any additional unassigned time entries from the **start of last month up to today's date** - previously it only checked from the start of the current month to today's date
    - If this code is run for example on the 7th July, then it will pick up all unassigned time entries for the month of June and for July so far
    - This means that #222 could use the `days_left` property alone by checking for projects with a negative `days_left`


Fixes #242 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
