### PR TITLE
263 prevent active

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -215,7 +215,7 @@ class Project(models.Model):
         Only relevant for active projects.
 
         Returns:
-            The number of weeks left or None if the project is not Active.
+            The number of weeks left or None if the project is in Draft.
         """
         if self.status != "Draft" and self.end_date and self.start_date:
             left = (self.end_date - datetime.now().date()).days / 7

--- a/main/models.py
+++ b/main/models.py
@@ -203,6 +203,11 @@ class Project(models.Model):
         if self.end_date <= self.start_date:
             raise ValidationError("The end date must be after the start date.")
 
+        if self.status == "Active" and not self.funding_source.exists():
+            raise ValidationError(
+                "Active projects must have at least 1 funding source."
+            )
+
     @property
     def weeks_to_deadline(self) -> tuple[int, float] | None:
         """Provide the number of weeks left until project deadline.
@@ -212,7 +217,7 @@ class Project(models.Model):
         Returns:
             The number of weeks left or None if the project is not Active.
         """
-        if self.status == "Active" and self.end_date and self.start_date:
+        if self.status != "Draft" and self.end_date and self.start_date:
             left = (self.end_date - datetime.now().date()).days / 7
             total = (self.end_date - self.start_date).days / 7
             return int(left), round(left / total * 100, 1)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -45,7 +45,7 @@ def project(user, department):
         lead=user,
         start_date=datetime.now().date(),
         end_date=datetime.now().date() + timedelta(days=42),
-        status="Active",
+        status="Not Started",
     )[0]
 
 

--- a/tests/main/test_tasks.py
+++ b/tests/main/test_tasks.py
@@ -298,13 +298,15 @@ class TestSyncClockifyTimeEntries:
     @patch("main.tasks.ClockifyAPI")
     @patch("main.tasks.timezone.now")
     def test_sync_creates_new_entry(
-        self, mock_now, mock_clockify_api, mock_settings, user, project
+        self, mock_now, mock_clockify_api, mock_settings, user, funding
     ):
         """Test that a new time entry from the API is created in the database."""
         mock_now.return_value = timezone.make_aware(datetime(2025, 7, 16, 10, 0, 0))
         mock_settings.CLOCKIFY_API_KEY = "fake_key"
         mock_settings.CLOCKIFY_WORKSPACE_ID = "fake_workspace"
+        project = funding.project
         project.clockify_id = "proj_1"
+        project.status = "Active"
         project.save()
 
         mock_api_instance = mock_clockify_api.return_value
@@ -343,12 +345,14 @@ class TestSyncClockifyTimeEntries:
     @patch("main.tasks.settings")
     @patch("main.tasks.ClockifyAPI")
     def test_api_call_exception(
-        self, mock_clockify_api, mock_settings, project, caplog
+        self, mock_clockify_api, mock_settings, funding, caplog
     ):
         """Test that an error is logged if the API call fails."""
         mock_settings.CLOCKIFY_API_KEY = "fake_key"
         mock_settings.CLOCKIFY_WORKSPACE_ID = "fake_workspace"
+        project = funding.project
         project.clockify_id = "proj_1"
+        project.status = "Active"
         project.save()
 
         mock_api_instance = mock_clockify_api.return_value
@@ -363,12 +367,14 @@ class TestSyncClockifyTimeEntries:
     @patch("main.tasks.settings")
     @patch("main.tasks.ClockifyAPI")
     def test_skips_incomplete_entry(
-        self, mock_clockify_api, mock_settings, user, project, caplog
+        self, mock_clockify_api, mock_settings, user, funding, caplog
     ):
         """Test that entries with missing data are skipped."""
         mock_settings.CLOCKIFY_API_KEY = "fake_key"
         mock_settings.CLOCKIFY_WORKSPACE_ID = "fake_workspace"
+        project = funding.project
         project.clockify_id = "proj_1"
+        project.status = "Active"
         project.save()
 
         mock_api_instance = mock_clockify_api.return_value
@@ -384,12 +390,14 @@ class TestSyncClockifyTimeEntries:
     @patch("main.tasks.settings")
     @patch("main.tasks.ClockifyAPI")
     def test_skips_entry_if_user_not_found(
-        self, mock_clockify_api, mock_settings, project, caplog
+        self, mock_clockify_api, mock_settings, funding, caplog
     ):
         """Test that entries are skipped if the user does not exist in the database."""
         mock_settings.CLOCKIFY_API_KEY = "fake_key"
         mock_settings.CLOCKIFY_WORKSPACE_ID = "fake_workspace"
+        project = funding.project
         project.clockify_id = "proj_1"
+        project.status = "Active"
         project.save()
 
         mock_api_instance = mock_clockify_api.return_value
@@ -420,6 +428,8 @@ def test_monthly_days_used_not_exceeding_days_left(user, project, funding):
 
     funding.project = project
     funding.save()
+    project.status = "Active"
+    project.save()
 
     # Create a time entry within the allowed days
     start_time = datetime(2025, 6, 1, 11, 0)
@@ -444,6 +454,8 @@ def test_monthly_days_used_exceeding_days_left(user, project, funding):
 
     funding.project = project
     funding.save()
+    project.status = "Active"
+    project.save()
 
     # Create a time entry that exceeds the days left
     start_time = datetime(2025, 6, 1, 11, 0)

--- a/tests/main/test_utils.py
+++ b/tests/main/test_utils.py
@@ -227,6 +227,8 @@ def test_days_used_exceeding_days_left(user, project):
         daily_rate=400,
         expiry_date=current_month_start + timedelta(days=30),  # Not expired
     )
+    project.status = "Active"
+    project.save()
 
     result = get_projects_with_days_used_exceeding_days_left(date=date)
 


### PR DESCRIPTION
# Description

Adds another condition in the `Projects.clean` method to check if there is a funding source when the project is active. 

Most of the changes are related to fixing tests, to make them work with this new condtion.

Fixes #263 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
