### PR TITLE
Select time range in cost recovery plots

### DIFF
--- a/main/plots.py
+++ b/main/plots.py
@@ -216,7 +216,7 @@ def create_cost_recovery_plots(
 
     Args:
         dates: list of tuples (from oldest to most recent) containing dates for all
-            months of the last 5 years; each tuple contains two dates for the first
+            months of the last 3 years; each tuple contains two dates for the first
             and last date of the month
         start_date: datetime object representing the start of the timeseries plotting
             period
@@ -281,7 +281,7 @@ def create_cost_recovery_layout() -> Row:
     # Get x-axis values for bar plot
     chart_months = [f"{date[0].strftime('%b')} {date[0].year}" for date in dates]
 
-    # Plots are initialised with data for last 5 years but only the last year is shown
+    # Plots are initialised with data for last 3 years but only the last year is shown
     # by default
     timeseries_plot, bar_plot = create_cost_recovery_plots(
         dates=dates,

--- a/main/plots.py
+++ b/main/plots.py
@@ -318,6 +318,7 @@ def create_cost_recovery_layout() -> Row:
         plot=timeseries_plot,
         start_picker=start_picker,
         end_picker=end_picker,
+        include_future_dates=False,
     )
     widgets.add_bar_callback_to_button(
         button=calendar_button,
@@ -336,6 +337,7 @@ def create_cost_recovery_layout() -> Row:
         plot=timeseries_plot,
         start_picker=start_picker,
         end_picker=end_picker,
+        include_future_dates=False,
     )
     widgets.add_bar_callback_to_button(
         button=financial_button,

--- a/main/plots.py
+++ b/main/plots.py
@@ -245,20 +245,14 @@ def create_cost_recovery_plots(
         {"timeseries": capacity_timeseries, "colour": "navy", "label": "Capacity"},
     ]
     timeseries_plot = create_timeseries_plot(
-        title=(
-            f"Team capacity and project charging from {start_date.strftime('%B')} "
-            f"{start_date.year} to {end_date.strftime('%B')} {end_date.year}"
-        ),
+        title=("Team capacity and project charging over time"),
         traces=traces,
         x_range=x_range,
     )
 
     # Create bar plot for monthly charges
     bar_plot = create_bar_plot(
-        title=(
-            f"Monthly charges from {start_date.strftime('%B')} {start_date.year} to "
-            f"{end_date.strftime('%B')} {end_date.year}"
-        ),
+        title=("Total monthly charges"),
         months=chart_months,
         values=monthly_totals,
         x_range=(chart_months[-12:]),

--- a/main/plots.py
+++ b/main/plots.py
@@ -6,9 +6,9 @@ from typing import Any
 import pandas as pd
 from bokeh.embed import components
 from bokeh.layouts import column, row
-from bokeh.models import ColumnDataSource, HoverTool
+from bokeh.models import ColumnDataSource, HoverTool, Range1d
 from bokeh.models.layouts import Row
-from bokeh.models.widgets import Button, Range1d
+from bokeh.models.widgets import Button
 from bokeh.plotting import figure
 
 from . import timeseries, widgets
@@ -309,7 +309,7 @@ def create_cost_recovery_layout() -> Row:
     )
 
     # Create button to set plots to calendar year
-    calendar_button = widgets.get_button(
+    calendar_button = Button(
         label="Current calendar year",
     )
     widgets.add_callback_to_button(
@@ -327,7 +327,7 @@ def create_cost_recovery_layout() -> Row:
     )
 
     # Create button to set plots to financial year
-    financial_button = widgets.get_button(
+    financial_button = Button(
         label="Current financial year",
     )
     widgets.add_callback_to_button(

--- a/main/plots.py
+++ b/main/plots.py
@@ -81,7 +81,6 @@ def create_timeseries_plot(  # type: ignore[explicit-any]
         background_fill_color="#efefef",
         x_axis_type="datetime",  # type: ignore[call-arg]
         tools="save,xpan,xwheel_zoom,reset",
-        # x_range=,
     )
     if x_range:
         plot.x_range = Range1d(x_range[0], x_range[1])
@@ -148,7 +147,8 @@ def create_capacity_planning_layout() -> Row:
         A Row object (the Row containing a Column or widgets and the plot).
     """
     start, end = datetime.now(), datetime.now() + timedelta(days=365)
-    min_date, max_date = start - timedelta(365 * 5), start + timedelta(365 * 5)
+    # Min and max dates are previous an
+    min_date, max_date = start - timedelta(days=1095), start + timedelta(days=1095)
 
     # Get the plot to display (it is created with all data, but only the dates
     # in the x_range provided are shown)

--- a/main/plots.py
+++ b/main/plots.py
@@ -273,9 +273,8 @@ def create_cost_recovery_layout() -> Row:
     Creates the cost recovery timeseries plot and bar plot for monthly charges, plus the
     associated widgets used to control the data displayed in the plots.
 
-    # TODO: update Returns statement
     Returns:
-        A Row object (the Row containing a Column or widgets and the plot).
+        A Row object (the Row containing a Column of widgets and a Column of plots).
     """
     dates = get_month_dates_for_previous_years()
 
@@ -314,9 +313,45 @@ def create_cost_recovery_layout() -> Row:
         chart_months=chart_months,
     )
 
+    # Create button to set plots to calendar year
+    calendar_button = widgets.get_button(
+        label="Current calendar year",
+    )
+    widgets.add_callback_to_button(
+        button=calendar_button,
+        dates=get_calendar_year_dates(),
+        plot=timeseries_plot,
+        start_picker=start_picker,
+        end_picker=end_picker,
+    )
+    widgets.add_bar_callback_to_button(
+        button=calendar_button,
+        dates=get_calendar_year_dates(),
+        plot=bar_plot,
+        chart_months=chart_months,
+    )
+
+    # Create button to set plots to financial year
+    financial_button = widgets.get_button(
+        label="Current financial year",
+    )
+    widgets.add_callback_to_button(
+        button=financial_button,
+        dates=get_financial_year_dates(),
+        plot=timeseries_plot,
+        start_picker=start_picker,
+        end_picker=end_picker,
+    )
+    widgets.add_bar_callback_to_button(
+        button=financial_button,
+        dates=get_financial_year_dates(),
+        plot=bar_plot,
+        chart_months=chart_months,
+    )
+
     # Create layout to display widgets aligned as a column next to the plot
     plot_layout = row(
-        column(start_picker, end_picker),
+        column(start_picker, end_picker, calendar_button, financial_button),
         column(timeseries_plot, bar_plot),
     )
     return plot_layout

--- a/main/templates/main/cost_recovery.html
+++ b/main/templates/main/cost_recovery.html
@@ -21,10 +21,7 @@
 
   <h2>Cost recovery plots</h2>
 
-  {{ timeseries_script | safe }}
-  {{ timeseries_div | safe }}
-
-  {{ bar_script | safe }}
-  {{ bar_div | safe }}
+  {{ script | safe }}
+  {{ div | safe }}
 
 {% endblock content %}

--- a/main/utils.py
+++ b/main/utils.py
@@ -242,7 +242,7 @@ def get_calendar_year_dates() -> tuple[datetime, datetime]:
 def get_financial_year_dates() -> tuple[datetime, datetime]:
     """Get the start and end dates for the current financial year."""
     today = datetime.now()
-    if today.month >= 8:
+    if today.month > 8:
         start = today.replace(day=1, month=8)
         end = today.replace(day=31, month=7, year=today.year + 1)
     else:

--- a/main/utils.py
+++ b/main/utils.py
@@ -229,3 +229,23 @@ def order_queryset_by_property(  # type: ignore[explicit-any]
     )
     queryset = queryset.order_by(preserved_ordering)
     return queryset
+
+
+def get_calendar_year_dates() -> tuple[datetime, datetime]:
+    """Get the start and end dates for the current calendar year."""
+    today = datetime.now()
+    start = today.replace(day=1, month=1)
+    end = today.replace(day=31, month=12)
+    return start, end
+
+
+def get_financial_year_dates() -> tuple[datetime, datetime]:
+    """Get the start and end dates for the current financial year."""
+    today = datetime.now()
+    if today.month >= 8:
+        start = today.replace(day=1, month=8)
+        end = today.replace(day=31, month=7, year=today.year + 1)
+    else:
+        start = today.replace(day=1, month=8, year=today.year - 1)
+        end = today.replace(day=31, month=7, year=today.year)
+    return start, end

--- a/main/utils.py
+++ b/main/utils.py
@@ -135,13 +135,13 @@ def get_budget_status(
     return funds_ran_out_not_expired, funding_expired_budget_left
 
 
-def get_month_dates_for_previous_year() -> list[tuple[date, date]]:
-    """Get the start and end date of each month for the previous year."""
+def get_month_dates_for_previous_years() -> list[tuple[date, date]]:
+    """Get the start and end date of each month for the previous 3 years."""
     dates = []
     today = datetime.today().date()
 
     start_current_month = today.replace(day=1)
-    for _ in range(12):
+    for _ in range(36):
         end_prev_month = start_current_month - timedelta(days=1)
         start_prev_month = end_prev_month.replace(day=1)
         dates.append((start_prev_month, end_prev_month))

--- a/main/views.py
+++ b/main/views.py
@@ -143,7 +143,7 @@ class CapacityPlanningView(LoginRequiredMixin, TemplateView):
         min_date, max_date = start - timedelta(365 * 5), start + timedelta(365 * 5)
 
         # Get the plot to display (it is created with all data, but only the dates
-        # in the default range are shown)
+        # in the x_range provided are shown)
         plot = plots.create_capacity_planning_plot(
             start_date=min_date, end_date=max_date, x_range=(start, end)
         )

--- a/main/views.py
+++ b/main/views.py
@@ -158,8 +158,7 @@ class CostRecoveryView(LoginRequiredMixin, FormView):  # type: ignore [type-arg]
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:  # type: ignore
         """Add HTML components and Bokeh version to the context."""
         context = super().get_context_data(**kwargs)
-        timeseries_plot, bar_plot = plots.create_cost_recovery_plots()
-        context.update(plots.html_components_from_plot(timeseries_plot, "timeseries"))
-        context.update(plots.html_components_from_plot(bar_plot, "bar"))
+        layout = plots.create_cost_recovery_layout()
+        context.update(plots.html_components_from_plot(layout))
         context["bokeh_version"] = bokeh.__version__
         return context

--- a/main/views.py
+++ b/main/views.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 from typing import Any
 
 import bokeh
+from bokeh.layouts import column, row
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.forms import Form, ModelForm
 from django.http import HttpRequest, HttpResponse
@@ -19,7 +20,7 @@ from django.views.generic import (
 from django_filters.views import FilterView
 from django_tables2 import RequestConfig, SingleTableMixin
 
-from . import forms, models, plots, report, tables
+from . import forms, models, plots, report, tables, utils, widgets
 
 
 def index(request: HttpRequest) -> HttpResponse:
@@ -137,10 +138,46 @@ class CapacityPlanningView(LoginRequiredMixin, TemplateView):
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:  # type: ignore
         """Add HTML components and Bokeh version to the context."""
         context = super().get_context_data(**kwargs)
+
+        start, end = datetime.now(), datetime.now() + timedelta(days=365)
+        min_date, max_date = start - timedelta(365 * 5), start + timedelta(365 * 5)
+
+        # Get the plot to display (it is created with all data, but only the dates
+        # in the default range are shown)
         plot = plots.create_capacity_planning_plot(
-            datetime.now(), datetime.now() + timedelta(365)
+            start_date=min_date, end_date=max_date, x_range=(start, end)
         )
-        context.update(plots.html_components_from_plot(plot))
+
+        # Get widgets to control the dates shown in the plot
+        start_picker, end_picker = widgets.get_plot_date_pickers(
+            min_date=min_date.date(),
+            max_date=max_date.date(),
+            default_start=start.date(),
+            default_end=end.date(),
+            plot=plot,
+        )
+
+        calendar_button = widgets.get_xrange_button(
+            label="Current calendar year",
+            dates=utils.get_calendar_year_dates(),
+            plot=plot,
+            start_picker=start_picker,
+            end_picker=end_picker,
+        )
+
+        financial_button = widgets.get_xrange_button(
+            label="Current financial year",
+            dates=utils.get_financial_year_dates(),
+            plot=plot,
+            start_picker=start_picker,
+            end_picker=end_picker,
+        )
+
+        # Create layout to display widgets aligned as a column next to the plot
+        layout = row(
+            column(start_picker, end_picker, calendar_button, financial_button), plot
+        )
+        context.update(plots.html_components_from_plot(layout))
         context["bokeh_version"] = bokeh.__version__
         return context
 

--- a/main/widgets.py
+++ b/main/widgets.py
@@ -55,6 +55,48 @@ def add_timeseries_callback_to_date_pickers(
     end_picker.js_on_change("value", callback)
 
 
+def add_bar_callback_to_date_pickers(
+    start_picker: DatePicker,
+    end_picker: DatePicker,
+    plot: figure,
+    chart_months: list[str],
+) -> None:
+    """Add the JS callback to start and end date pickers to update a plot x_range.
+
+    Args:
+        start_picker: The start date picker to add the callback to
+        end_picker: The end date picker to add the callback to
+        plot: The plot modified by the date pickers
+        chart_months: list of months for x-axis in bar chart
+    """
+    # JS code dictates what happens when a new date is selected on the pickers
+    callback = CustomJS(
+        args=dict(
+            start_picker=start_picker,
+            end_picker=end_picker,
+            plot=plot,
+            months=chart_months,
+        ),
+        code="""
+const start_year = new Date(start_picker.value).getFullYear();
+const start_month = new Date(start_picker.value).toLocaleString(
+'default', { month: 'short' });
+const end_year = new Date(end_picker.value).getFullYear();
+const end_month = new Date(end_picker.value).toLocaleString(
+'default', {month: 'short' });
+
+const start_index = months.indexOf(`${start_month} ${start_year}`);
+const end_index   = months.indexOf(`${end_month} ${end_year}`);
+const selected_months = months.slice(start_index, end_index + 1);
+
+plot.x_range.factors = selected_months;
+""",
+    )  # x_range in the plot is updated with dates parsed from the date pickers
+
+    start_picker.js_on_change("value", callback)
+    end_picker.js_on_change("value", callback)
+
+
 def get_plot_date_pickers(
     min_date: date,
     max_date: date,

--- a/main/widgets.py
+++ b/main/widgets.py
@@ -1,0 +1,118 @@
+"""Widgets to be used to interact with the plots."""
+
+from datetime import date, datetime
+
+from bokeh.models import CustomJS
+from bokeh.models.widgets import Button, DatePicker
+from bokeh.plotting import figure
+
+
+def date_picker(
+    title: str, default_date: date, min_date: date, max_date: date
+) -> DatePicker:
+    """Provides a Date Picker widget to select dates in the plots.
+
+    Args:
+        title: Title to display above the Date Picker.
+        default_date: The initial date to display
+        min_date: The earliest possible date the user can select
+        max_date: The latest possible date the user can select
+
+    Returns:
+        The initialised Date Picker widget.
+    """
+    picker = DatePicker(
+        title=title,
+        value=default_date,
+        min_date=min_date,
+        max_date=max_date,
+    )
+    return picker
+
+
+def get_plot_date_pickers(
+    min_date: date, max_date: date, default_start: date, default_end: date, plot: figure
+) -> tuple[DatePicker, DatePicker]:
+    """Get start and end date pickers for a timeseries plot.
+
+    Creates separate date pickers to choose the start and end date to use as the x_range
+    for a plot. Both pickers are provided with a default date to display and minimum
+    and maximum possible dates that the user can select.
+
+    Args:
+        min_date: The earliest possible date the user can select
+        max_date: The latest possible date the user can select
+        default_start: The default date to display in the start picker
+        default_end: The default date to display in the end picker
+        plot: The plot that the date pickers will be used to update
+
+    Returns: A tuple of date pickers for selecting the start and end dates of
+
+    """
+    start_picker = date_picker(
+        title="Select start date:",
+        default_date=default_start,
+        min_date=min_date,
+        max_date=max_date,
+    )
+    end_picker = date_picker(
+        title="Select end date:",
+        default_date=default_end,
+        min_date=min_date,
+        max_date=max_date,
+    )
+
+    callback = CustomJS(
+        args=dict(
+            start_picker=start_picker, end_picker=end_picker, x_range=plot.x_range
+        ),
+        code="""const start = Date.parse(start_picker.value);
+            const end = Date.parse(end_picker.value);
+            x_range.start = start
+            x_range.end = end""",
+    )
+
+    start_picker.js_on_change("value", callback)
+    end_picker.js_on_change("value", callback)
+    return start_picker, end_picker
+
+
+def get_xrange_button(
+    label: str,
+    dates: tuple[datetime, datetime],
+    plot: figure,
+    start_picker: DatePicker,
+    end_picker: DatePicker,
+) -> Button:
+    """Get button to control dates shown in timeseries plot.
+
+    The date pickers are provided so that the default date that is displayed can also
+    be updated to match what is being shown in the plot/
+
+    Args:
+        label: Label to display on the button
+        dates: Tuple of datetimes used to update the plot x_range
+        plot: The plot the button will be used to update
+        start_picker: The start date picker to update
+        end_picker: The end date picker to update
+
+    Returns:
+        A Bokeh button that can be used to update the x_range shown in a plot.
+    """
+    button = Button(label=label)
+    button.js_on_click(
+        CustomJS(
+            args=dict(
+                start=dates[0],
+                end=dates[1],
+                x_range=plot.x_range,
+                start_picker=start_picker,
+                end_picker=end_picker,
+            ),
+            code="""x_range.start = start;
+            x_range.end = end;
+            start_picker.value = new Date(start).toISOString().split('T')[0];
+            end_picker.value = new Date(end).toISOString().split('T')[0];""",
+        )
+    )
+    return button

--- a/main/widgets.py
+++ b/main/widgets.py
@@ -30,8 +30,36 @@ def date_picker(
     return picker
 
 
+def add_timeseries_callback_to_date_pickers(
+    start_picker: DatePicker, end_picker: DatePicker, plot: figure
+) -> None:
+    """Add the JS callback to start and end date pickers to update a plot x_range.
+
+    Args:
+        start_picker: The start date picker to add the callback to
+        end_picker: The end date picker to add the callback to
+        plot: The plot modified by the date pickers
+    """
+    # JS code dictates what happens when a new date is selected on the pickers
+    callback = CustomJS(
+        args=dict(
+            start_picker=start_picker, end_picker=end_picker, x_range=plot.x_range
+        ),
+        code="""const start = Date.parse(start_picker.value);
+            const end = Date.parse(end_picker.value);
+            x_range.start = start
+            x_range.end = end""",
+    )  # x_range in the plot is updated with dates parsed from the date pickers
+
+    start_picker.js_on_change("value", callback)
+    end_picker.js_on_change("value", callback)
+
+
 def get_plot_date_pickers(
-    min_date: date, max_date: date, default_start: date, default_end: date, plot: figure
+    min_date: date,
+    max_date: date,
+    default_start: date,
+    default_end: date,
 ) -> tuple[DatePicker, DatePicker]:
     """Get start and end date pickers for a timeseries plot.
 
@@ -44,7 +72,6 @@ def get_plot_date_pickers(
         max_date: The latest possible date the user can select
         default_start: The default date to display in the start picker
         default_end: The default date to display in the end picker
-        plot: The plot that the date pickers will be used to update
 
     Returns: A tuple of date pickers for selecting the start and end dates of
 
@@ -62,45 +89,25 @@ def get_plot_date_pickers(
         max_date=max_date,
     )
 
-    # JS code dictates what happens when a new date is selected on the pickers
-    callback = CustomJS(
-        args=dict(
-            start_picker=start_picker, end_picker=end_picker, x_range=plot.x_range
-        ),
-        code="""const start = Date.parse(start_picker.value);
-            const end = Date.parse(end_picker.value);
-            x_range.start = start
-            x_range.end = end""",
-    )  # x_range in the plot is updated with dates parsed from the date pickers
-
-    start_picker.js_on_change("value", callback)
-    end_picker.js_on_change("value", callback)
     return start_picker, end_picker
 
 
-def get_xrange_button(
-    label: str,
+def add_callback_to_button(
+    button: Button,
     dates: tuple[datetime, datetime],
     plot: figure,
     start_picker: DatePicker,
     end_picker: DatePicker,
-) -> Button:
-    """Get button to control dates shown in timeseries plot.
-
-    The date pickers are provided so that the default date that is displayed can also
-    be updated to match what is being shown in the plot/
+) -> None:
+    """Add the JS callback to a button to update a plot x_range and picker dates.
 
     Args:
-        label: Label to display on the button
+        button: The button to add the callback to
         dates: Tuple of datetimes used to update the plot x_range
         plot: The plot the button will be used to update
         start_picker: The start date picker to update
         end_picker: The end date picker to update
-
-    Returns:
-        A Bokeh button that can be used to update the x_range shown in a plot.
     """
-    button = Button(label=label)
     # JS code dictates what happens when the button is clicked
     button.js_on_click(
         CustomJS(
@@ -117,4 +124,18 @@ def get_xrange_button(
             end_picker.value = new Date(end).toISOString().split('T')[0];""",
         )  # x_range in plot and dates displayed in pickers are updated
     )
+
+
+def get_button(
+    label: str,
+) -> Button:
+    """Get button widget.
+
+    Args:
+        label: Label to display on the button
+
+    Returns:
+        A Bokeh button that can be used to update the x_range shown in a plot.
+    """
+    button = Button(label=label)
     return button

--- a/main/widgets.py
+++ b/main/widgets.py
@@ -62,6 +62,7 @@ def get_plot_date_pickers(
         max_date=max_date,
     )
 
+    # JS code dictates what happens when a new date is selected on the pickers
     callback = CustomJS(
         args=dict(
             start_picker=start_picker, end_picker=end_picker, x_range=plot.x_range
@@ -70,7 +71,7 @@ def get_plot_date_pickers(
             const end = Date.parse(end_picker.value);
             x_range.start = start
             x_range.end = end""",
-    )
+    )  # x_range in the plot is updated with dates parsed from the date pickers
 
     start_picker.js_on_change("value", callback)
     end_picker.js_on_change("value", callback)
@@ -100,6 +101,7 @@ def get_xrange_button(
         A Bokeh button that can be used to update the x_range shown in a plot.
     """
     button = Button(label=label)
+    # JS code dictates what happens when the button is clicked
     button.js_on_click(
         CustomJS(
             args=dict(
@@ -113,6 +115,6 @@ def get_xrange_button(
             x_range.end = end;
             start_picker.value = new Date(start).toISOString().split('T')[0];
             end_picker.value = new Date(end).toISOString().split('T')[0];""",
-        )
+        )  # x_range in plot and dates displayed in pickers are updated
     )
     return button

--- a/main/widgets.py
+++ b/main/widgets.py
@@ -61,7 +61,13 @@ def add_bar_callback_to_date_pickers(
     plot: figure,
     chart_months: list[str],
 ) -> None:
-    """Add the JS callback to start and end date pickers to update a plot x_range.
+    """Add the JS callback to start and end date pickers to update a bar plot x_range.
+
+    As the x-range is categorical, we supply the list of formatted chart_months, index
+    the list using the dates selected in the date pickers, and use the indexed list to
+    update x_range.factors. '(window.skip_bar_picker_callback)' is used to prevent
+    interference when the plot is updated using the buttons (otherwise when the buttons
+    update the date pickers, this callback is also run).
 
     Args:
         start_picker: The start date picker to add the callback to
@@ -77,24 +83,25 @@ def add_bar_callback_to_date_pickers(
             plot=plot,
             months=chart_months,
         ),
-        code="""
-const start_year = new Date(start_picker.value).getFullYear();
-const start_month = new Date(start_picker.value).toLocaleString(
-'default', { month: 'short' });
-const end_year = new Date(end_picker.value).getFullYear();
-const end_month = new Date(end_picker.value).toLocaleString(
-'default', {month: 'short' });
+        code="""if (window.skip_bar_picker_callback) return;
 
-const start_index = months.indexOf(`${start_month} ${start_year}`);
-const end_index   = months.indexOf(`${end_month} ${end_year}`);
-const selected_months = months.slice(start_index, end_index + 1);
+        function getIndex(picker_value) {
+            const date = new Date(picker_value);
+            const month = date.toLocaleString('default', { month: 'short' });
+            const year = date.getFullYear();
+            const formatted_month = `${month} ${year}`;
+            return months.indexOf(formatted_month);
+        }
 
-plot.x_range.factors = selected_months;
-""",
+        const start_index = getIndex(start_picker.value);
+        const end_index = getIndex(end_picker.value);
+        const selected_months = months.slice(start_index, end_index + 1);
+
+        plot.x_range.factors = selected_months;""",
     )  # x_range in the plot is updated with dates parsed from the date pickers
 
-    start_picker.js_on_change("value", callback)
-    end_picker.js_on_change("value", callback)
+    start_picker.js_on_change("change", callback)
+    end_picker.js_on_change("change", callback)
 
 
 def get_plot_date_pickers(
@@ -165,6 +172,44 @@ def add_callback_to_button(
             start_picker.value = new Date(start).toISOString().split('T')[0];
             end_picker.value = new Date(end).toISOString().split('T')[0];""",
         )  # x_range in plot and dates displayed in pickers are updated
+    )
+
+
+def add_bar_callback_to_button(
+    button: Button,
+    dates: tuple[datetime, datetime],
+    plot: figure,
+    chart_months: list[str],
+) -> None:
+    """Add the JS callback to a button to update a plot x_range and picker dates.
+
+    'window.skip_bar_picker_callback = true' is used to prevent the callback in
+    add_bar_callback_to_date_pickers from being run concurrently.
+
+    Args:
+        button: The button to add the callback to
+        dates: Tuple of datetimes used to update the plot x_range
+        plot: The plot the button will be used to update
+        chart_months: list of months for x-axis in bar chart
+    """
+    # Get formatted dates to use as x-range in plot
+    start_tick = f"{dates[0].strftime('%b')} {dates[0].year}"
+    end_tick = f"{dates[1].strftime('%b')} {dates[1].year}"
+
+    start = chart_months.index(start_tick)
+    end = chart_months.index(end_tick) + 1 if end_tick in chart_months else None
+    indexed_months = chart_months[start:end]
+
+    # JS code dictates what happens when the button is clicked
+    button.js_on_click(
+        CustomJS(
+            args=dict(
+                indexed_months=indexed_months,
+                plot=plot,
+            ),
+            code="""window.skip_bar_picker_callback = true;
+            plot.x_range.factors = indexed_months;""",
+        )  # x_range in plot updated
     )
 
 

--- a/tests/main/test_plots.py
+++ b/tests/main/test_plots.py
@@ -1,6 +1,6 @@
 """Tests for the plots module."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 
 import pytest
 
@@ -32,7 +32,7 @@ def test_create_cost_recovery_plot(project, funding):
     from bokeh.models import HoverTool
     from bokeh.plotting import figure
 
-    from main import models, plots
+    from main import models, plots, utils
 
     # Create a Monthly Charge for the plot
     models.MonthlyCharge.objects.create(
@@ -41,19 +41,20 @@ def test_create_cost_recovery_plot(project, funding):
         amount=100.00,
         date=datetime.today().date() - timedelta(100),
     )
-    ts_plot, bar_plot = plots.create_cost_recovery_plots()
+
+    # Create cost recovery plots
+    dates = utils.get_month_dates_for_previous_years()
+    min_date = datetime.combine(dates[0][0], time.min)
+    max_date = datetime.combine(dates[-1][1], time.min)
+    start = datetime.combine(dates[-12][0], time.min)
+    chart_months = [f"{date[0].strftime('%b')} {date[0].year}" for date in dates]
+    ts_plot, bar_plot = plots.create_cost_recovery_plots(
+        dates, min_date, max_date, (start, max_date), chart_months
+    )
 
     # Test timeseries plot
     assert isinstance(ts_plot, figure)
-
-    first_of_month = datetime.today().date().replace(day=1)
-    end_date = (first_of_month - timedelta(days=1)).replace(day=1)
-    start_date = first_of_month.replace(year=end_date.year - 1)
-
-    ts_title = (
-        f"Team capacity and project charging from {start_date.strftime('%B')} "
-        f"{start_date.year} to {end_date.strftime('%B')} {end_date.year}"
-    )
+    ts_title = "Team capacity and project charging over time"
     assert ts_plot.title.text == ts_title
     assert ts_plot.yaxis.axis_label == "Value"
     assert ts_plot.xaxis.axis_label == "Date"
@@ -65,10 +66,7 @@ def test_create_cost_recovery_plot(project, funding):
     # Test bar plot
     assert isinstance(bar_plot, figure)
 
-    bar_title = (
-        f"Monthly charges from {start_date.strftime('%B')} {start_date.year} "
-        f"to {end_date.strftime('%B')} {end_date.year}"
-    )
+    bar_title = "Total monthly charges"
     assert bar_plot.title.text == bar_title
     assert bar_plot.yaxis.axis_label == "Total charge (£)"
     assert bar_plot.xaxis.axis_label == "Month-Year"

--- a/tests/main/test_timeseries.py
+++ b/tests/main/test_timeseries.py
@@ -172,7 +172,7 @@ def test_get_cost_recovery_timeseries(department, user, analysis_code):
     report.create_actual_monthly_charges(project, start_last_month, end_last_month)
 
     # Create cost recovery timeseries
-    dates = utils.get_month_dates_for_previous_year()
+    dates = utils.get_month_dates_for_previous_years()
     ts, charge_totals = timeseries.get_cost_recovery_timeseries(dates)
 
     # Get expected value
@@ -262,7 +262,7 @@ def test_get_cost_recovery_timeseries_equal_to_num_people(
     report.create_actual_monthly_charges(project, start_last_month, end_last_month)
 
     # Create cost recovery timeseries
-    dates = utils.get_month_dates_for_previous_year()
+    dates = utils.get_month_dates_for_previous_years()
     ts = timeseries.get_cost_recovery_timeseries(dates)[0]
 
     # Expected value for 2 individuals working full-time on projects would be 2.0

--- a/tests/main/test_utils.py
+++ b/tests/main/test_utils.py
@@ -1,6 +1,7 @@
 """Tests for the utils module."""
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
+from unittest.mock import patch
 
 import pytest
 from django.contrib.auth.models import Group
@@ -312,19 +313,11 @@ def test_get_financial_year_dates():
     """Test the get_financial_year_dates function."""
     from main.utils import get_financial_year_dates
 
-    today = datetime.now()
+    with patch("main.utils.datetime") as datetime_mock:
+        datetime_mock.now.return_value = datetime(2025, 8, 1, 10, 0, 0, 0)
+        assert get_financial_year_dates()[0].date() == date(2024, 8, 1)
+        assert get_financial_year_dates()[1].date() == date(2025, 7, 31)
 
-    if today.month > 8:
-        assert get_financial_year_dates()[0].date() == datetime(today.year, 8, 1).date()
-        assert (
-            get_financial_year_dates()[1].date()
-            == datetime(today.year + 1, 7, 31).date()
-        )
-    else:
-        assert (
-            get_financial_year_dates()[0].date()
-            == datetime(today.year - 1, 8, 1).date()
-        )
-        assert (
-            get_financial_year_dates()[1].date() == datetime(today.year, 7, 31).date()
-        )
+        datetime_mock.now.return_value = datetime(2025, 9, 1, 10, 0, 0, 0)
+        assert get_financial_year_dates()[0].date() == date(2025, 8, 1)
+        assert get_financial_year_dates()[1].date() == date(2026, 7, 31)

--- a/tests/main/test_utils.py
+++ b/tests/main/test_utils.py
@@ -295,3 +295,34 @@ def test_order_queryset_by_property(project, analysis_code):
     reverse_qs = utils.order_queryset_by_property(qs, "effort", True)
     reverse_ids = list(reverse_qs.values_list("id", flat=True))
     assert reverse_ids == [2, 1, 3]
+
+
+def test_get_calendar_year_dates():
+    """Test the get_calendar_year_dates function."""
+    from main.utils import get_calendar_year_dates
+
+    today = datetime.now()
+    assert get_calendar_year_dates()[0].date() == datetime(today.year, 1, 1).date()
+    assert get_calendar_year_dates()[1].date() == datetime(today.year, 12, 31).date()
+
+
+def test_get_financial_year_dates():
+    """Test the get_financial_year_dates function."""
+    from main.utils import get_financial_year_dates
+
+    today = datetime.now()
+
+    if today.month >= 8:
+        assert get_financial_year_dates()[0].date() == datetime(today.year, 8, 1).date()
+        assert (
+            get_financial_year_dates()[1].date()
+            == datetime(today.year + 1, 7, 31).date()
+        )
+    else:
+        assert (
+            get_financial_year_dates()[0].date()
+            == datetime(today.year - 1, 8, 1).date()
+        )
+        assert (
+            get_financial_year_dates()[1].date() == datetime(today.year, 7, 31).date()
+        )

--- a/tests/main/test_utils.py
+++ b/tests/main/test_utils.py
@@ -312,7 +312,7 @@ def test_get_financial_year_dates():
 
     today = datetime.now()
 
-    if today.month >= 8:
+    if today.month > 8:
         assert get_financial_year_dates()[0].date() == datetime(today.year, 8, 1).date()
         assert (
             get_financial_year_dates()[1].date()

--- a/tests/main/test_views.py
+++ b/tests/main/test_views.py
@@ -234,10 +234,8 @@ class TestCostRecoveryView(LoginRequiredMixin, TemplateOkMixin):
         endpoint = reverse("main:cost_recovery")
         response = auth_client.get(endpoint)
         assert response.status_code == HTTPStatus.OK
-        assert "<script" in response.context["timeseries_script"]
-        assert "<div" in response.context["timeseries_div"]
-        assert "<script" in response.context["bar_script"]
-        assert "<div" in response.context["bar_div"]
+        assert "<script" in response.context["script"]
+        assert "<div" in response.context["div"]
         assert response.context["bokeh_version"] == bokeh.__version__
 
     def test_form_valid(self, user):

--- a/tests/main/test_widgets.py
+++ b/tests/main/test_widgets.py
@@ -74,7 +74,10 @@ def test_add_bar_callback_to_date_pickers():
             plot=bar_plot,
             months=chart_months,
         ),
-        code="""if (window.skip_bar_picker_callback) return;
+        code="""if (window.skip_bar_picker_callback) {
+            window.skip_bar_picker_callback = false;
+            return;
+        }
 
         function getIndex(picker_value) {
             const date = new Date(picker_value);

--- a/tests/main/test_widgets.py
+++ b/tests/main/test_widgets.py
@@ -1,6 +1,6 @@
 """Test suite for the plot widgets."""
 
-from datetime import datetime, timedelta
+from datetime import datetime, time, timedelta
 from unittest.mock import patch
 
 import pytest
@@ -49,6 +49,62 @@ def test_add_timeseries_callback_to_date_pickers():
 
 
 @pytest.mark.django_db
+def test_add_bar_callback_to_date_pickers():
+    """Test the add_bar_callback_to_date_pickers function."""
+    from main import plots, utils, widgets
+
+    dates = utils.get_month_dates_for_previous_years()
+    min_date = datetime.combine(dates[0][0], time.min)
+    max_date = datetime.combine(dates[-1][1], time.min)
+    start = datetime.combine(dates[-12][0], time.min)
+    chart_months = [f"{date[0].strftime('%b')} {date[0].year}" for date in dates]
+
+    start_picker, end_picker = widgets.get_plot_date_pickers(
+        min_date.date(), max_date.date(), start.date(), max_date.date()
+    )
+
+    _, bar_plot = plots.create_cost_recovery_plots(
+        dates, min_date, max_date, (start, max_date), chart_months
+    )
+
+    expected_callback = CustomJS(
+        args=dict(
+            start_picker=start_picker,
+            end_picker=end_picker,
+            plot=bar_plot,
+            months=chart_months,
+        ),
+        code="""if (window.skip_bar_picker_callback) return;
+
+        function getIndex(picker_value) {
+            const date = new Date(picker_value);
+            const month = date.toLocaleString('default', { month: 'short' });
+            const year = date.getFullYear();
+            const formatted_month = `${month} ${year}`;
+            return months.indexOf(formatted_month);
+        }
+
+        const start_index = getIndex(start_picker.value);
+        const end_index = getIndex(end_picker.value);
+        const selected_months = months.slice(start_index, end_index + 1);
+
+        plot.x_range.factors = selected_months;""",
+    )
+
+    # Check js_on_change called with the expected arguments
+    with patch.object(DatePicker, "js_on_change") as js_mock:
+        widgets.add_bar_callback_to_date_pickers(
+            start_picker, end_picker, bar_plot, chart_months
+        )
+        assert js_mock.call_count == 2
+
+        called_args = js_mock.call_args.args
+        assert called_args[0] == "change"
+        assert called_args[1].args == expected_callback.args
+        assert called_args[1].code == expected_callback.code
+
+
+@pytest.mark.django_db
 def test_add_callback_to_button():
     """Test the add_callback_to_button function."""
     from main import plots, utils, widgets
@@ -89,6 +145,51 @@ def test_add_callback_to_button():
     with patch.object(Button, "js_on_click") as js_mock:
         widgets.add_callback_to_button(
             button, calendar_dates, plot, start_picker, end_picker
+        )
+        js_mock.assert_called_once()
+
+        called_arg = js_mock.call_args.args[0]
+        assert called_arg.args == expected_callback.args
+        assert called_arg.code == expected_callback.code
+
+
+@pytest.mark.django_db
+def test_add_bar_callback_to_button():
+    """Test the add_bar_callback_to_button function."""
+    from main import plots, utils, widgets
+
+    dates = utils.get_month_dates_for_previous_years()
+    min_date = datetime.combine(dates[0][0], time.min)
+    max_date = datetime.combine(dates[-1][1], time.min)
+    start = datetime.combine(dates[-12][0], time.min)
+    chart_months = [f"{date[0].strftime('%b')} {date[0].year}" for date in dates]
+
+    _, bar_plot = plots.create_cost_recovery_plots(
+        dates, min_date, max_date, (start, max_date), chart_months
+    )
+    button = Button(label="button")
+
+    calendar_dates = utils.get_calendar_year_dates()
+    end_month = f"{calendar_dates[1].strftime('%b')} {calendar_dates[1].year}"
+    idxs = (
+        chart_months.index(
+            f"{calendar_dates[0].strftime('%b')} {calendar_dates[0].year}"
+        ),
+        chart_months.index(end_month) if end_month in chart_months else None,
+    )
+    expected_callback = CustomJS(
+        args=dict(
+            indexed_months=chart_months[idxs[0] : idxs[1]],
+            plot=bar_plot,
+        ),
+        code="""window.skip_bar_picker_callback = true;
+            plot.x_range.factors = indexed_months;""",
+    )
+
+    # Check js_on_click called with the expected arguments
+    with patch.object(Button, "js_on_click") as js_mock:
+        widgets.add_bar_callback_to_button(
+            button, calendar_dates, bar_plot, chart_months
         )
         js_mock.assert_called_once()
 


### PR DESCRIPTION
# Description

This PR adds the ability to select time range in cost recovery plots (both timeseries plot and bar chart)

- This is slightly more complicated than just updating the timeseries plot alone as the bar plots have categorical axes
  - `plot.x_range.factors` is updated for categorical axes 
  - To get the right x_range, we index the `chart_months` (containing the x tick labels) according to the dates selected
- Updating the dates with the calendar/financial year buttons has to be managed slightly differently
  - Initially, the dates shown in the bar plot wouldn't update until you clicked the button twice
  - This is because when you click the button, the callback in  `add_bar_callback_to_button` updates `x_range.factors` and also sets the values for the date pickers (so the default dates displayed are up to date with what is in the plot)
  - This meant that the callback in `add_bar_callback_to_date_pickers` was also being run, which led to some conflict
  - To avoid this, we set a global variable `window.skip_bar_picker_callback` to True in the button callback, to prevent the date picker callback from running

https://github.com/user-attachments/assets/c7adbfa7-f3bd-49dc-b914-fd30023450f7


Other notes
- The data for the last 3 years are generated but only the last year is displayed initially
- When clicking the buttons, the bar plot will only display up to the current date/month (the x axes won't extend to dates in the future)
- I changed the utils function `get_financial_year_dates`, so if currently in the month of August, the dates (/data) for the previous financial year are shown (otherwise no data is displayed)
- Changed the plot titles to be more generic as the dates are flexible

Fixes #238 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
