### PR TITLE
Add minute to crontab for notify_monthly_time_logged_summary

### DIFF
--- a/main/tasks.py
+++ b/main/tasks.py
@@ -147,7 +147,7 @@ def notify_monthly_time_logged_logic(
 
 
 # Runs on the 3rd day of every month at 10:00 AM
-@db_periodic_task(crontab(day=3, hour=10))
+@db_periodic_task(crontab(day=3, hour=10, minute=0))
 def notify_monthly_time_logged_summary() -> None:
     """Monthly task to notify users about their time logged."""
     last_month_start, last_month_name, current_month_start, current_month_name = (


### PR DESCRIPTION
# Description

Send  time logged summary email only once (minute missing from crontab as in #269)

Fixes #298

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
