### PR TITLE
Skips internal projects from having charges reports

### DIFF
--- a/main/report.py
+++ b/main/report.py
@@ -217,7 +217,9 @@ def write_to_csv(
             writer.writerow(row)
 
 
-def _get_projects_to_create_report_for(start_date: date, end_date: date) -> QuerySet:
+def _get_projects_to_create_report_for(
+    start_date: date, end_date: date
+) -> QuerySet[models.Project]:
     """Get the models for which to create the report.
 
     These are the ones that overlap with the time period to charge, that are external

--- a/main/report.py
+++ b/main/report.py
@@ -1,4 +1,4 @@
-"""Report for including all the charges to be expensed for the month."""
+"Report for including all the charges to be expensed for the month."""
 
 import csv
 import io
@@ -242,8 +242,9 @@ def create_charges_report(month: int, year: int, writer: Writer) -> None:
         end_date__gte=start_date,
         start_date__isnull=False,
         end_date__isnull=False,
+        funding_source__source="External"
     ).exclude(charging="Manual")
-
+    
     for project in projects:
         if project.charging == "Pro-rata":
             create_pro_rata_monthly_charges(project, start_date, end_date)

--- a/tests/main/test_report.py
+++ b/tests/main/test_report.py
@@ -584,3 +584,54 @@ def test_create_charges_report_for_attachment(department, user, analysis_code):
 
     # Check the charge row in the CSV is as expected
     assert expected_charge_row in csv_string
+
+
+@pytest.mark.django_db
+def test_get_projects_to_create_report_for(department, user, analysis_code):
+    """Test the _get_projects_to_create_report_for function."""
+    from main import models, report
+
+    start_date = date(2025, 6, 1)
+    end_date = date(2025, 7, 1)
+
+    # Create time entry for monthly charge
+    project = models.Project.objects.create(
+        name="ProCAT",
+        department=department,
+        lead=user,
+        start_date=start_date,
+        end_date=end_date,
+        status="Active",
+        charging="Actual",
+    )
+    funding = models.Funding.objects.create(
+        project=project,
+        source="External",
+        funding_body="Funding body",
+        cost_centre="centre",
+        activity="G12345",
+        analysis_code=analysis_code,
+        expiry_date=end_date,
+        budget=10000.00,
+        daily_rate=100.00,
+    )
+    models.TimeEntry.objects.create(
+        user=user,
+        project=project,
+        start_time=datetime(2025, 6, 2, 9, 0),
+        end_time=datetime(2025, 6, 2, 12, 30),
+    )
+    # There should be 1
+    assert len(report._get_projects_to_create_report_for(start_date, end_date)) == 1
+
+    # If the project's charging method is manual, there should be none
+    project.charging = "Manual"
+    project.save()
+    assert len(report._get_projects_to_create_report_for(start_date, end_date)) == 0
+
+    # If the project's funding is internal, there should none, as well
+    project.charging = "Actual"
+    project.save()
+    funding.source = "Internal"
+    funding.save()
+    assert len(report._get_projects_to_create_report_for(start_date, end_date)) == 0


### PR DESCRIPTION
# Description

Having "External" funding has been defined as a requirement for the filter that selects what projects should have a monthly report.

Fixes #304 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
