### PR TITLE
Adds filters to admin

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -23,12 +23,7 @@ click==8.2.1
     #   djlint
     #   pip-tools
 colorama==0.4.6
-    # via
-    #   build
-    #   click
-    #   djlint
-    #   pytest
-    #   tqdm
+    # via djlint
 contourpy==1.3.3
     # via bokeh
 coverage[toml]==7.9.2
@@ -54,6 +49,8 @@ django==5.2.6
     #   django-tables2
     #   mozilla-django-oidc
     #   procat (pyproject.toml)
+django-admin-rangefilter==0.13.3
+    # via procat (pyproject.toml)
 django-bootstrap5==25.2
     # via procat (pyproject.toml)
 django-crispy-forms==2.4
@@ -199,9 +196,7 @@ typing-extensions==4.14.1
     #   django-stubs-ext
     #   mypy
 tzdata==2025.2
-    # via
-    #   django
-    #   pandas
+    # via pandas
 urllib3==2.5.0
     # via
     #   requests

--- a/doc-requirements.txt
+++ b/doc-requirements.txt
@@ -22,9 +22,7 @@ click==8.2.1
     # via mkdocs
 colorama==0.4.6
     # via
-    #   click
     #   griffe
-    #   mkdocs
     #   mkdocs-material
 contourpy==1.3.3
     # via bokeh
@@ -43,6 +41,8 @@ django==5.2.6
     #   django-tables2
     #   mozilla-django-oidc
     #   procat (pyproject.toml)
+django-admin-rangefilter==0.13.3
+    # via procat (pyproject.toml)
 django-bootstrap5==25.2
     # via procat (pyproject.toml)
 django-crispy-forms==2.4
@@ -179,9 +179,7 @@ tornado==6.5.1
 types-requests==2.32.4.20250611
     # via procat (pyproject.toml)
 tzdata==2025.2
-    # via
-    #   django
-    #   pandas
+    # via pandas
 urllib3==2.5.0
     # via
     #   requests

--- a/main/admin.py
+++ b/main/admin.py
@@ -2,6 +2,7 @@
 
 from django.contrib import admin
 from django.contrib.auth.admin import UserAdmin
+from rangefilter.filters import DateRangeQuickSelectListFilterBuilder
 
 from .models import (
     AnalysisCode,
@@ -74,6 +75,7 @@ class TimeEntryAdmin(admin.ModelAdmin):  # type: ignore [type-arg]
         "start_time",
         "end_time",
     )
+    list_filter = ("user", "project")
 
 
 @admin.register(MonthlyCharge)
@@ -87,3 +89,4 @@ class MonthlyChargeAdmin(admin.ModelAdmin):  # type: ignore [type-arg]
         "date",
         "description",
     )
+    list_filter = ("project", ("date", DateRangeQuickSelectListFilterBuilder()))

--- a/procat/settings/settings.py
+++ b/procat/settings/settings.py
@@ -128,6 +128,7 @@ INSTALLED_APPS += [
     "django_filters",
     "huey.contrib.djhuey",
     "mozilla_django_oidc",
+    "rangefilter",
 ]
 
 MIDDLEWARE.insert(1, "whitenoise.middleware.WhiteNoiseMiddleware")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,7 +65,7 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
-module = ["django_tables2.*", "django_filters.*", "mozilla_django_oidc.*"]
+module = ["django_tables2.*", "django_filters.*", "mozilla_django_oidc.*", "rangefilter.*"]
 ignore_missing_imports = true
 
 [[tool.mypy.overrides]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,8 @@ dependencies = [
     "requests",
     "bokeh",
     "pandas",
-    "mozilla-django-oidc"
+    "mozilla-django-oidc",
+    "django-admin-rangefilter"
 ]
 
 [project.optional-dependencies]

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,8 @@ django==5.2.6
     #   django-tables2
     #   mozilla-django-oidc
     #   procat (pyproject.toml)
+django-admin-rangefilter==0.13.3
+    # via procat (pyproject.toml)
 django-bootstrap5==25.2
     # via procat (pyproject.toml)
 django-crispy-forms==2.4
@@ -89,9 +91,7 @@ tornado==6.5.1
 types-requests==2.32.4.20250611
     # via procat (pyproject.toml)
 tzdata==2025.2
-    # via
-    #   django
-    #   pandas
+    # via pandas
 urllib3==2.5.0
     # via
     #   requests


### PR DESCRIPTION
# Description

So a couple of models that will be mostly used in the Admin, can be filtered. I've added an extra dependency that enable a better handling of the filtering for date fields. 

Fixes #324

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
