### PR TITLE
Fix adding time entries to monthly charges

### DIFF
--- a/main/admin.py
+++ b/main/admin.py
@@ -68,6 +68,8 @@ class ProjectAdmin(admin.ModelAdmin):  # type: ignore [type-arg]
 class TimeEntryAdmin(admin.ModelAdmin):  # type: ignore [type-arg]
     """Admin class for the TimeEntry model."""
 
+    filter_horizontal = ("monthly_charge",)
+
     list_display = (
         "user",
         "project",


### PR DESCRIPTION
# Description

This PR adds a `ModelAdmin.filter_horizontal` to the `monthly_charge` field of the `TimeEntry` model. I think all the monthly charges are not actually 'added' but by default a multiple select box is used to display a ManyToManyField, which means all the charges are displayed? After adding the horizontal filter only the relevant charges are shown as 'chosen'.

<img width="670" height="311" alt="monthly charges" src="https://github.com/user-attachments/assets/399baf2d-964e-4a5b-ac81-1d3be7726f65" />


Fixes #307 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
