### PR TITLE
Fix logic for funding status notif

### DIFF
--- a/main/tasks.py
+++ b/main/tasks.py
@@ -178,7 +178,7 @@ _template_funding_expired_but_has_budget = """
 Dear {lead},
 
 The project {project_name} has expired, but there is still unspent funds of
-£{budget} available.
+£{funding_left} available (£{budget} total).
 
 Please check the funding status and take necessary actions.
 
@@ -195,7 +195,7 @@ def notify_funding_status_logic(
         date=date
     )
 
-    if funds_ran_out_not_expired.exists():
+    if len(funds_ran_out_not_expired) > 0:
         for funding in funds_ran_out_not_expired:
             subject = f"[Funding Update] {funding.project.name}"
             head_email = get_head_email()
@@ -215,7 +215,7 @@ def notify_funding_status_logic(
                 head_email=head_email,
             )
 
-    if funding_expired_budget_left.exists():
+    if len(funding_expired_budget_left) > 0:
         for funding in funding_expired_budget_left:
             subject = f"[Funding Expired] {funding.project.name}"
             head_email = get_head_email()
@@ -225,6 +225,7 @@ def notify_funding_status_logic(
             message = _template_funding_expired_but_has_budget.format(
                 lead=lead_name,
                 project_name=funding.project.name,
+                funding_left=funding.funding_left,
                 budget=funding.budget,
             )
             email_user_and_cc_head(

--- a/main/utils.py
+++ b/main/utils.py
@@ -126,12 +126,15 @@ def get_budget_status(
     if date is None:
         date = datetime.today().date()
 
-    funds_ran_out_not_expired = Funding.objects.filter(
-        expiry_date__gt=date, budget__lt=0
-    )
-    funding_expired_budget_left = Funding.objects.filter(
-        expiry_date__lt=date, budget__gt=0
-    )
+    funds_ran_out_not_expired = Funding.objects.filter(expiry_date__gt=date)
+    funds_ran_out_not_expired = [
+        fund for fund in funds_ran_out_not_expired if fund.funding_left <= 0
+    ]
+
+    funding_expired_budget_left = Funding.objects.filter(expiry_date__lt=date)
+    funding_expired_budget_left = [
+        fund for fund in funding_expired_budget_left if fund.funding_left > 0
+    ]
     return funds_ran_out_not_expired, funding_expired_budget_left
 
 

--- a/main/utils.py
+++ b/main/utils.py
@@ -121,17 +121,17 @@ def get_head_email() -> list[str]:
 
 def get_budget_status(
     date: date | None = None,
-) -> tuple[QuerySet[Funding], QuerySet[Funding]]:
+) -> tuple[list[Funding], list[Funding]]:
     """Get the budget status of a funding."""
     if date is None:
         date = datetime.today().date()
 
-    funds_ran_out_not_expired = Funding.objects.filter(expiry_date__gt=date)
+    funds_ran_out_not_expired = list(Funding.objects.filter(expiry_date__gt=date))
     funds_ran_out_not_expired = [
         fund for fund in funds_ran_out_not_expired if fund.funding_left <= 0
     ]
 
-    funding_expired_budget_left = Funding.objects.filter(expiry_date__lt=date)
+    funding_expired_budget_left = list(Funding.objects.filter(expiry_date__lt=date))
     funding_expired_budget_left = [
         fund for fund in funding_expired_budget_left if fund.funding_left > 0
     ]

--- a/tests/main/test_tasks.py
+++ b/tests/main/test_tasks.py
@@ -204,7 +204,7 @@ def test_funding_expired_but_has_budget(funding, project):
     expected_message = (
         f"\nDear {funding.project.lead.get_full_name()},\n\n"
         f"The project {project.name} has expired, but there is still unspent "
-        f"funds of\n£{funding.budget} available.\n\n"
+        f"funds of\n£{funding.funding_left} available (£{funding.budget} total).\n\n"
         f"Please check the funding status and take necessary actions.\n\n"
         f"Best regards,\nProCAT\n"
     )

--- a/tests/main/test_utils.py
+++ b/tests/main/test_utils.py
@@ -112,7 +112,7 @@ def test_get_current_and_last_month_start():
 @pytest.mark.django_db
 def test_get_budget_status():
     """Test get_budget_status function."""
-    from main.models import Department, Funding, Project
+    from main.models import Department, Funding, MonthlyCharge, Project
     from main.utils import get_budget_status
 
     today = datetime.today().date()
@@ -132,17 +132,20 @@ def test_get_budget_status():
     funding2 = Funding.objects.create(
         project=project,
         budget=5000,
-        expiry_date=today - timedelta(days=30),  # Expired
+        expiry_date=today - timedelta(days=30),  # Expired but has budget
     )
     funding3 = Funding.objects.create(
         project=project,
-        budget=-1000,
+        budget=1000,
         expiry_date=today + timedelta(days=30),  # Ran out but not expired
     )
-    funding4 = Funding.objects.create(
+
+    # Create monthly charge to deplete funding 3
+    MonthlyCharge.objects.create(
+        date=today,
         project=project,
-        budget=2000,
-        expiry_date=today - timedelta(days=30),  # Expired but has budget
+        funding=funding3,
+        amount=2000.00,
     )
 
     funds_ran_out_not_expired, funding_expired_budget_left = get_budget_status(
@@ -150,14 +153,12 @@ def test_get_budget_status():
     )
 
     # Check the results
-    assert funds_ran_out_not_expired.count() == 1
-    assert funds_ran_out_not_expired.first() == funding3
+    assert len(funds_ran_out_not_expired) == 1
+    assert funds_ran_out_not_expired[0] == funding3
     assert funding2 not in funds_ran_out_not_expired
-    assert funding4 not in funds_ran_out_not_expired
 
     # Check funding expired but has budget
     assert funding2 in funding_expired_budget_left
-    assert funding4 in funding_expired_budget_left
     assert funding1 not in funding_expired_budget_left
     assert funding3 not in funding_expired_budget_left
 


### PR DESCRIPTION
# Description

This PR makes use of the `funding.funding_left` property instead of `funding.budget` when checking if funds are expired and notifying the project lead.

Summary
- `utils.get_budget_status` uses `funding.funding_left` instead of `funding.budget` (filtering property means this becomes a list rather than a queryset)
- `tasks.notify_funding_status_logic` reports the `funding_left` in email to project lead

Fixes #331 
Fixes #325

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
