### PR TITLE
adding a setting to configure the frequency of pulling data. 

### DIFF
--- a/main/tasks.py
+++ b/main/tasks.py
@@ -369,7 +369,7 @@ def sync_clockify_time_entries(
             )
 
 
-@db_periodic_task(crontab(day_of_week="mon", hour=2, minute=0))
+@db_periodic_task(crontab(**settings.HUEY_TASK_SCHEDULES["SYNC_CLOCKIFY_TIME_ENTRIES"]))
 def sync_clockify_time_entries_task() -> None:
     """Scheduled task to sync time entries from Clockify API."""
     sync_clockify_time_entries()

--- a/procat/settings/settings.py
+++ b/procat/settings/settings.py
@@ -178,3 +178,10 @@ OIDC_OP_USER_ENDPOINT = os.environ.get("OIDC_OP_USER_ENDPOINT")
 OIDC_OP_JWKS_ENDPOINT = os.environ.get("OIDC_OP_JWKS_ENDPOINT")
 OIDC_RP_SCOPES = os.environ.get("OIDC_RP_SCOPES")
 OIDC_RP_SIGN_ALGO = os.environ.get("OIDC_RP_SIGN_ALGO", "RS256")
+
+HUEY_TASK_SCHEDULES = {
+    "SYNC_CLOCKIFY_TIME_ENTRIES": {
+        "hour": 0,
+        "minute": 0,
+    },
+}


### PR DESCRIPTION

# Description

Added the Huey task schedule to settings to easily configure the frequency of pulling data from clockify. 
I have set it to midnight every day to fix #363 
 


Fixes #353  (issue)

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
