### PR TITLE
Calculate the right number of members

### DIFF
--- a/main/plots.py
+++ b/main/plots.py
@@ -314,7 +314,7 @@ def create_cost_recovery_plots(
         start_date=start_date, end_date=end_date
     )
 
-    number_team_members = timeseries.get_active_team_members(
+    number_team_members = timeseries.get_team_members_timeseries(
         start_date=start_date, end_date=end_date
     )
 


### PR DESCRIPTION
# Description

In this case, we need a time-dependent number of members, and not a single value, hence the need of calculate it as a series in order to get the right average capacity later on.

Fixes #360

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
