### PR TITLE
Hover tool rendered only for traces in capacity planning plot

### DIFF
--- a/main/plots.py
+++ b/main/plots.py
@@ -128,8 +128,9 @@ def create_timeseries_plot(  # type: ignore[explicit-any]
     plot.yaxis.axis_label = "Value"
     plot.xaxis.axis_label = "Date"
 
+    lines = []
     for trace in traces:
-        plot.line(
+        line = plot.line(
             "index",
             trace["label"],
             source=source,
@@ -137,6 +138,7 @@ def create_timeseries_plot(  # type: ignore[explicit-any]
             color=trace["colour"],
             legend_label=trace["label"],
         )
+        lines.append(line)
 
     # If provided, add varea shading between traces
     if vareas:
@@ -149,6 +151,7 @@ def create_timeseries_plot(  # type: ignore[explicit-any]
             ("Value", "$y{0.00}"),
         ],
         formatters={"$x": "datetime"},
+        renderers=lines,
     )
     plot.add_tools(hover)
 


### PR DESCRIPTION
# Description

This PR makes a change to the hover tool in the capacity planning plot so it only appears when hovering over the traces.

Fixes #400 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
