### PR TITLE
Check funding only when project has pk value

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -209,17 +209,16 @@ class Project(models.Model):
         if self.end_date <= self.start_date:
             raise ValidationError("The end date must be after the start date.")
 
-        if self.status in ("Active", "Confirmed") and not self.funding_source.exists():
-            raise ValidationError(
-                "Active and Confirmed projects must have at least 1 funding source."
-            )
+        if self.pk is not None and self.status in ("Active", "Confirmed"):
+            if not self.funding_source.exists():
+                raise ValidationError(
+                    "Active and Confirmed projects must have at least 1 funding source."
+                )
 
-        if self.status in ("Active", "Confirmed") and not all(
-            [f.is_complete() for f in self.funding_source.all()]
-        ):
-            raise ValidationError(
-                "Funding of Active and Confirmed projects must be complete."
-            )
+            if not all([f.is_complete() for f in self.funding_source.all()]):
+                raise ValidationError(
+                    "Funding of Active and Confirmed projects must be complete."
+                )
 
     @property
     def weeks_to_deadline(self) -> tuple[int, float] | None:

--- a/tests/main/test_models.py
+++ b/tests/main/test_models.py
@@ -91,10 +91,13 @@ class TestProject:
             status="Tentative",
         )
         project.clean()
-        project.save()
+
+        # Change to active but no pk value
+        project.status = "Active"
+        project.clean()
 
         # No funding, no active
-        project.status = "Active"
+        project.save()
         with pytest.raises(
             ValidationError,
             match="Active and Confirmed projects must have at least 1 funding source.",


### PR DESCRIPTION
# Description

This PR only checks if an Active project has funding associated if there is already a `self.pk` value associated.
The test is modified to check this.

Fixes #399

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
