### PR TITLE
Fix traces values

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -866,12 +866,15 @@ class FullTimeEquivalent(models.Model):
         If timerange is provided, those dates are used, otherwise a datetime index is
         created using the start and end dates of the FTE object.
         """
-        if timerange:
+        if timerange is not None:
             idx = timerange.copy()
+            output = pd.Series(0.0, index=idx)
+            output.loc[self.start_date : self.end_date] = self.value
         else:
             idx = pd.date_range(start=self.start_date, end=self.end_date)
+            output = pd.Series(self.value, index=idx)
 
-        return pd.Series(self.value, index=idx)
+        return output
 
     def clean(self) -> None:
         """Ensure start date comes before end date and that value 0 or positive."""

--- a/main/models.py
+++ b/main/models.py
@@ -869,7 +869,9 @@ class FullTimeEquivalent(models.Model):
         if timerange is not None:
             idx = timerange.copy()
             output = pd.Series(0.0, index=idx)
-            output.loc[self.start_date : self.end_date] = self.value
+            output.loc[pd.Timestamp(self.start_date) : pd.Timestamp(self.end_date)] = (
+                self.value
+            )
         else:
             idx = pd.date_range(start=self.start_date, end=self.end_date)
             output = pd.Series(self.value, index=idx)

--- a/tests/main/test_models.py
+++ b/tests/main/test_models.py
@@ -3,6 +3,7 @@
 from contextlib import nullcontext as does_not_raise
 from datetime import date, datetime, timedelta
 
+import pandas as pd
 import pytest
 from django.core.exceptions import ValidationError
 from django.utils import timezone
@@ -830,6 +831,27 @@ class TestMonthlyCharge:
 
 class TestProjectPhase:
     """Tests for the Project Phase model."""
+
+    def test_trace(self) -> None:
+        """Test the trace method."""
+        from main import models
+
+        start_date = datetime(2025, 1, 1).date()
+        end_date = datetime(2025, 1, 3).date()
+        project_phase = models.ProjectPhase(
+            value=1,
+            start_date=start_date,
+            end_date=end_date,
+        )
+        project_timerange = pd.date_range(start=start_date, end=end_date)
+        assert (project_phase.trace() == 1).all()
+
+        timerange = pd.date_range(
+            start=datetime(2024, 12, 1).date(), end=datetime(2025, 2, 1).date()
+        )
+        output = project_phase.trace(timerange)
+        assert (output.loc[project_timerange] == 1).all()
+        assert (output.loc[~output.index.isin(project_timerange)] == 0).all()
 
     def test_model_str(self, project_static):
         """Test the object string for the monthly charge model."""


### PR DESCRIPTION
# Description

This were calculated wrongly when an external time range was provided.

Fixes #518 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
