### PR TITLE
Updates the pro-rata charging process

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -1,6 +1,6 @@
 """Models module for main app."""
 
-from datetime import datetime, timedelta
+from datetime import date, datetime, timedelta
 from decimal import Decimal
 from typing import Any
 
@@ -606,24 +606,38 @@ class Funding(models.Model):
         """
         return float(round(self.funding_left / self.daily_rate, 1))
 
-    @property
-    def monthly_pro_rata_charge(self) -> float | None:
+    def monthly_pro_rata_charge(self, date: date) -> float | None:
         """Calculate the charge per month if the project has Pro-rata charging.
 
         Calculates the number of months between project start and end date regardless
         of the day of the month so the monthly charge will be the same regardless
         of the number of days in the month.
+
+        The last month of the project is not charged, so the charge applies from the
+        month of the start date until the month before the end date, to ensure that no
+        charges are made outside of the project period. For example, if a project
+        starts on 15th January and ends on 10th April, the charge will apply for
+        January, February and March, but not April.
+
+        Args:
+            date: The date for which to calculate the monthly charge, used to check if
+            the project has started and hasn't ended yet.
+
+        Returns:
+            The monthly charge amount, or None if the project doesn't have Pro-rata
+            charging or the date is outside the project period.
         """
         if (
             self.project.charging == "Pro-rata"
             and self.project.start_date
             and self.project.end_date
+            and self.project.start_date.month
+            <= date.month
+            < self.project.end_date.month
         ):
             months = (
-                (self.project.end_date.year - self.project.start_date.year) * 12
-                + (self.project.end_date.month - self.project.start_date.month)
-                + 1
-            )
+                self.project.end_date.year - self.project.start_date.year
+            ) * 12 + (self.project.end_date.month - self.project.start_date.month)
             return float(self.budget / months)
         return None
 

--- a/main/models.py
+++ b/main/models.py
@@ -621,7 +621,7 @@ class Funding(models.Model):
 
         Args:
             date: The date for which to calculate the monthly charge, used to check if
-            the project has started and hasn't ended yet.
+                the project has started and hasn't ended yet.
 
         Returns:
             The monthly charge amount, or None if the project doesn't have Pro-rata

--- a/main/report.py
+++ b/main/report.py
@@ -78,13 +78,13 @@ def create_pro_rata_monthly_charges(
     funding_sources = get_valid_funding_sources(project, end_date)
 
     for funding in funding_sources:
-        if not funding.monthly_pro_rata_charge:
+        if (monthly_charge := funding.monthly_pro_rata_charge(start_date)) is None:
             continue
 
         charge = models.MonthlyCharge.objects.create(
             project=project,
             funding=funding,
-            amount=funding.monthly_pro_rata_charge,
+            amount=monthly_charge,
             date=start_date,
             status="Draft",
         )

--- a/tests/main/test_models.py
+++ b/tests/main/test_models.py
@@ -618,13 +618,13 @@ class TestFunding:
             analysis_code=analysis_code,
             budget=10000.00,
         )
-        assert funding.monthly_pro_rata_charge is None
+        assert funding.monthly_pro_rata_charge(date(2025, 3, 15)) is None
 
     @pytest.mark.django_db
     def test_monthly_pro_rata_charge(self, user, department, analysis_code):
         """Test the monthly_pro_rata_charge property."""
         start_date = date(2025, 3, 15)
-        end_date = date(2025, 7, 8)  # 5 equal monthly charges will be created
+        end_date = date(2025, 7, 8)  # 4 equal monthly charges will be created
         from main import models
 
         project = models.Project.objects.create(
@@ -643,8 +643,10 @@ class TestFunding:
             analysis_code=analysis_code,
             budget=10000.00,
         )
-        expected_charge = funding.budget / 5
-        assert funding.monthly_pro_rata_charge == expected_charge
+        expected_charge = funding.budget / 4
+        assert funding.monthly_pro_rata_charge(start_date) == expected_charge
+        # Last month is not charged, so the charge is None
+        assert funding.monthly_pro_rata_charge(end_date) is None
 
 
 class TestCapacity:

--- a/tests/main/test_report.py
+++ b/tests/main/test_report.py
@@ -137,7 +137,7 @@ def test_create_pro_rata_monthly_charges_missing_dates(department, user, analysi
     )
 
     # Check that no Pro-rata charge created (no funding.monthly_pro_rata_charge)
-    assert funding.monthly_pro_rata_charge is None
+    assert funding.monthly_pro_rata_charge(start_date) is None
     report.create_pro_rata_monthly_charges(project, start_date, end_date)
     assert not models.MonthlyCharge.objects.exists()
 
@@ -175,7 +175,7 @@ def test_create_pro_rata_monthly_charges(department, user, analysis_code):
     # Create Pro-rata charge and check amount
     report.create_pro_rata_monthly_charges(project, start_date, end_date)
     expected_amount = models.MonthlyCharge.objects.get(date=start_date).amount
-    assert funding.monthly_pro_rata_charge == expected_amount
+    assert funding.monthly_pro_rata_charge(start_date) == expected_amount
 
 
 @pytest.mark.django_db
@@ -545,7 +545,7 @@ def test_create_charges_report_for_download(department, user, analysis_code):
             funding_A.cost_centre,
             funding_A.activity,
             funding_A.analysis_code.code,
-            f"{funding_A.budget / 2:.2f}",
+            f"{funding_A.budget:.2f}",
             (
                 f"RSE Project {project_A.name} ({funding_A.cost_centre}_"
                 f"{funding_A.activity}): 6/2025 [rcs-manager@imperial.ac.uk]"


### PR DESCRIPTION
# Description

This is to ensure that no charging happens after the end of the project. So, if the project last from mid-January to mid-April, there will be 3 charges made, in January, February and March. As it was now, it would have been 4, including April, which goes beyond the end of the project. 

Fixes #597

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [x] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
