### PR TITLE
639 real time

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -1057,3 +1057,19 @@ class ProjectPhase(FullTimeEquivalent):
         self.check_overlapping_phases()
         self.check_phase_alignment()
         self.check_project_funding()
+
+    @property
+    def expected_days_left(self) -> float:
+        """Expected number of days left in the phase.
+
+        If the days were to be used homogenously over the phase length, this function
+        calculates how many days of effort are left from today. In phases that have not
+        started (today < start date), the days left will be the total number of days,
+        and phases that are gone (today > end date) the total number of days will be
+        zero.
+        """
+        total_calendar_days = (self.end_date - self.start_date).days
+        fraction_left = min(
+            1, max((self.end_date - timezone.now().date()).days, 0) / total_calendar_days
+        )
+        return fraction_left * self.days

--- a/main/models.py
+++ b/main/models.py
@@ -480,8 +480,8 @@ class Project(Warning, models.Model):
         excess_left = max(self.days_left[0] - expected_left, 0)
 
         # Period to use them
-        now = timezone.now().date()
-        day_difference = (self.end_date - now).days * WORKING_DAYS / 365
+        now = timezone.now()
+        day_difference = (self.end_date - now.date()).days * WORKING_DAYS / 365
 
         # Actual excess full time equivalent needed to use those days over the time left
         excess_fte = excess_left / day_difference

--- a/main/models.py
+++ b/main/models.py
@@ -455,8 +455,39 @@ class Project(Warning, models.Model):
         if self.phases.exists():
             return cast(  # type: ignore[explicit-any]
                 pd.Series, sum(phase.trace(timerange) for phase in self.phases.all())
-            )
+            ) + self._excess_fte(timerange)
         return pd.Series(0.0, index=timerange)
+
+    def _excess_fte(self, timerange: pd.DatetimeIndex) -> pd.Series:  # type: ignore[explicit-any]
+        """Calculate the excess FTE due to not using enough time of a project.
+
+        This will be homogeneously spread over the remaining time of the project. If
+        time left is more than what it should, then the excess FTE will be positive,
+        otherwise, it will be zero.
+
+        Args:
+            timerange: The timerange to calculate the excess FTE trace over.
+
+        Returns:
+            A pandas Series with the excess FTE trace over the timerange.
+        """
+        output = pd.Series(0.0, index=timerange)
+        if not self.phases.exists() or not self.days_left:
+            return output
+
+        # Extra days available
+        expected_left = sum(phase.expected_days_left for phase in self.phases.all())
+        excess_left = max(self.days_left[0] - expected_left, 0)
+
+        # Period to use them
+        now = timezone.now().date()
+        day_difference = (self.end_date - now).days * WORKING_DAYS / 365
+
+        # Actual excess full time equivalent needed to use those days over the time left
+        excess_fte = excess_left / day_difference
+        output.loc[now : pd.Timestamp(self.end_date, tz=UTC)] = excess_fte
+
+        return output
 
 
 class Funding(models.Model):
@@ -1062,7 +1093,7 @@ class ProjectPhase(FullTimeEquivalent):
     def expected_days_left(self) -> float:
         """Expected number of days left in the phase.
 
-        If the days were to be used homogenously over the phase length, this function
+        If the days were to be used homogeneously over the phase length, this function
         calculates how many days of effort are left from today. In phases that have not
         started (today < start date), the days left will be the total number of days,
         and phases that are gone (today > end date) the total number of days will be
@@ -1070,6 +1101,7 @@ class ProjectPhase(FullTimeEquivalent):
         """
         total_calendar_days = (self.end_date - self.start_date).days
         fraction_left = min(
-            1, max((self.end_date - timezone.now().date()).days, 0) / total_calendar_days
+            1,
+            max((self.end_date - timezone.now().date()).days, 0) / total_calendar_days,
         )
         return fraction_left * self.days

--- a/main/models.py
+++ b/main/models.py
@@ -471,6 +471,8 @@ class Project(Warning, models.Model):
         Returns:
             A pandas Series with the excess FTE trace over the timerange.
         """
+        assert self.end_date is not None
+
         output = pd.Series(0.0, index=timerange)
         if not self.phases.exists() or not self.days_left:
             return output

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -59,6 +59,35 @@ def project(user, department):
 
 
 @pytest.fixture
+def project_mid(user, department, analysis_code):
+    """Provides a project object halfway through it lifetime."""
+    from main import models
+
+    project = models.Project.objects.get_or_create(
+        name="ProCAT",
+        department=department,
+        lead=user,
+        start_date=timezone.now().date() - timedelta(days=42),
+        end_date=timezone.now().date() + timedelta(days=42),
+        status="Active",
+    )[0]
+
+    _ = models.Funding.objects.get_or_create(
+        project=project,
+        source="External",
+        funding_body="Funding body",
+        cost_centre="centre",
+        activity="G12345",
+        analysis_code=analysis_code,
+        expiry_date=timezone.now().date() + timedelta(days=42),
+        budget=10000.00,
+        daily_rate=389.00,
+    )[0]
+
+    return project
+
+
+@pytest.fixture
 def project_static(user, department, analysis_code):
     """Provides a statically dated project object with funding."""
     from main import models

--- a/tests/main/test_models.py
+++ b/tests/main/test_models.py
@@ -1244,3 +1244,45 @@ class TestProjectPhase:
         with validation_error as e:
             phase.clean()
         assert message is None or message in str(e)
+
+    def test_before_phase_returns_total_days(self, project_static):
+        """When today is before the start date, all days should remain."""
+        from main import models
+
+        today = timezone.now()
+        phase = models.ProjectPhase(
+            project=project_static,
+            value=0.7,
+            start_date=(today + timedelta(days=10)).date(),
+            end_date=(today + timedelta(days=40)).date(),
+        )
+
+        assert phase.expected_days_left == phase.days
+
+    def test_after_phase_returns_zero(self, project_static):
+        """When today is after the end date, no days should remain."""
+        from main import models
+
+        today = timezone.now()
+        phase = models.ProjectPhase(
+            project=project_static,
+            value=0.7,
+            start_date=(today - timedelta(days=40)).date(),
+            end_date=(today - timedelta(days=10)).date(),
+        )
+
+        assert phase.expected_days_left == 0
+
+    def test_midpoint_of_phase_returns_half_days(self, project_static):
+        """When today is exactly halfway through, half the days should remain."""
+        from main import models
+
+        today = timezone.now()
+        phase = models.ProjectPhase(
+            project=project_static,
+            value=0.7,
+            start_date=(today - timedelta(days=40)).date(),
+            end_date=(today + timedelta(days=40)).date(),
+        )
+
+        assert phase.expected_days_left == phase.days / 2

--- a/tests/main/test_models.py
+++ b/tests/main/test_models.py
@@ -408,6 +408,86 @@ class TestProject:
         ).all()
         assert (output.loc[~output.index.isin(timerange)] == 0).all()
 
+    @pytest.mark.django_db
+    def test_no_phases_returns_zero_series(self, project_mid):
+        """When no phases exist, the output should be all zeros."""
+        timerange = make_timerange(
+            start_date=project_mid.start_date, end_date=project_mid.end_date
+        )
+        result = project_mid._excess_fte(timerange)
+        assert (result == 0.0).all()
+
+    @pytest.mark.django_db
+    def test_no_excess_returns_zero_series(self, project_mid):
+        """When days_left <= expected_left across phases, excess FTE should be zero."""
+        from main import models
+
+        timerange = make_timerange(
+            start_date=project_mid.start_date, end_date=project_mid.end_date
+        )
+        models.ProjectPhase.from_days(
+            days=project_mid.total_effort,
+            start_date=project_mid.start_date,
+            end_date=project_mid.end_date,
+            project=project_mid,
+        )
+
+        # We have consumed most of the time
+        now = timezone.now()
+        models.TimeEntry.objects.create(
+            user=project_mid.lead,
+            project=project_mid,
+            start_time=now - timedelta(days=project_mid.total_effort + 1),
+            end_time=now,
+        )
+
+        # days_left[0] will be <= expected_days_left, so no excess
+        result = project_mid._excess_fte(timerange)
+        assert (result == 0.0).all()
+
+    @pytest.mark.django_db
+    def test_excess_returns_positive_fte_from_today_to_end_date(self, project_mid):
+        """When days_left > expected_left, a positive FTE is set from now to end."""
+        from main import models
+
+        timerange = make_timerange(
+            start_date=project_mid.start_date, end_date=project_mid.end_date
+        )
+        models.ProjectPhase.from_days(
+            days=project_mid.total_effort,
+            start_date=project_mid.start_date,
+            end_date=project_mid.end_date,
+            project=project_mid,
+        )
+
+        result = project_mid._excess_fte(timerange)
+
+        today = timezone.now()  # Already has tz
+        past = result[result.index < pd.Timestamp(today)]
+        future = result[
+            (result.index >= pd.Timestamp(today))
+            & (result.index <= pd.Timestamp(project_mid.end_date, tz=UTC))
+        ]
+
+        assert (past == 0.0).all()
+        assert (future > 0.0).all()
+
+
+def make_timerange(
+    start_date: datetime | None = None, end_date: datetime | None = None
+) -> pd.DatetimeIndex:
+    """A simple daily timerange."""
+    today = timezone.now()
+    start_date = start_date if start_date else today - timedelta(days=10)
+    end_date = end_date if end_date else today + timedelta(days=10)
+
+    return pd.date_range(
+        start=start_date,
+        end=end_date,
+        freq="D",
+        tz=UTC,
+    )
+
 
 class TestFunding:
     """Tests for the funding model."""


### PR DESCRIPTION
# Description

Use the time remaining in excess in a project to calculate an updated capacity for the team in the upcoming months.

Fixes #639 

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
