### PR TITLE
Instruct to clone repo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,16 @@ This Django project uses:
 
 To get started:
 
-1. Activate a git repository (required for `pre-commit` and the package versioning with
-`setuptools-scm`):
+1. Clone this repository:
 
    ```bash
-   git init
+   git clone https://github.com/ImperialCollegeLondon/proCAT.git
+   ```
+
+1. Move into the created repo.
+
+   ```bash
+   cd proCAT
    ```
 
 1. Create and activate a virtual environment. This creates a `.venv` in the same


### PR DESCRIPTION
# Description

The readme still has the original instructions from the template to run `git init`. This PR replaces that with an instruction to clone this repo

## Type of change

- [X] Documentation (non-breaking change that adds or improves the documentation)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [ ] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [ ] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [ ] Code is commented, particularly in hard-to-understand areas
- [ ] Tests added or an issue has been opened to tackle that in the future. (Indicate issue here: # (issue))
