### PR TITLE
Fix issue with projects with warnings being made active

### DIFF
--- a/main/models.py
+++ b/main/models.py
@@ -254,8 +254,8 @@ class Project(Warning, models.Model):
         """Ensure all fields have a value unless status is 'Tentative' or 'Not done'.
 
         It also checks that, if present, the end date is after the start date.
-        In addition, a project that was not yet 'Active' cannot have warnings; the
-        project must start clean
+        In addition, a project that was not yet 'Active', but wants to,
+        cannot have warnings; the project must start clean
         """
         if self.status == "Tentative" or self.status == "Not done":
             return super().clean()

--- a/main/models.py
+++ b/main/models.py
@@ -203,8 +203,10 @@ class Project(Warning, models.Model):
 
     def _warn_no_funding(self) -> None | str:
         """Warns if there is no funding associated to the project."""
-        if not self.funding_source.exists():
-            return "No funding defined for the project."
+        if not self.funding_source.exists() or not all(
+            [f.is_complete() for f in self.funding_source.all()]
+        ):
+            return "No funding defined for the project or incomplete row."
         return None
 
     def _warn_phase_lifetime(self) -> None | str:
@@ -269,23 +271,24 @@ class Project(Warning, models.Model):
         if self.end_date <= self.start_date:
             raise ValidationError("The end date must be after the start date.")
 
-        if self.status in ("Active", "Confirmed"):
-            if self.pk is None:
-                raise ValidationError(
-                    "Active and Confirmed projects must have at least 1 funding source."
-                )
-            else:
-                if not self.funding_source.exists() or not all(
-                    [f.is_complete() for f in self.funding_source.all()]
-                ):
-                    raise ValidationError(
-                        "Funding of Active and Confirmed projects must be complete."
-                    )
+        # No more checks if the projectstatus is not set to become
+        # 'Active' or 'Confirmed'
+        if self.status not in ("Active", "Confirmed"):
+            return
 
-        if self.pk is not None and self.status == "Active":
-            was_active = Project.objects.filter(pk=self.pk, status="Active").exists()
+        if self.pk is None:
+            raise ValidationError(
+                "Projects cannot be created directly in Active or Confirmed statuses."
+            )
+        else:
+            was_active = Project.objects.filter(
+                pk=self.pk, status__in=("Active", "Confirmed")
+            ).exists()
             if not was_active and self.has_warnings:
-                message = "A project cannot be made 'Active' if there are warnings:"
+                message = (
+                    "A project cannot be made Active or Confirmed if "
+                    "there are warnings:"
+                )
                 raise ValidationError([message, *self.warnings])
 
     @property

--- a/main/models.py
+++ b/main/models.py
@@ -254,6 +254,8 @@ class Project(Warning, models.Model):
         """Ensure all fields have a value unless status is 'Tentative' or 'Not done'.
 
         It also checks that, if present, the end date is after the start date.
+        In addition, a project that was not yet 'Active' cannot have warnings; the
+        project must start clean
         """
         if self.status == "Tentative" or self.status == "Not done":
             return super().clean()
@@ -267,16 +269,24 @@ class Project(Warning, models.Model):
         if self.end_date <= self.start_date:
             raise ValidationError("The end date must be after the start date.")
 
-        if self.pk is not None and self.status in ("Active", "Confirmed"):
-            if not self.funding_source.exists():
+        if self.status in ("Active", "Confirmed"):
+            if self.pk is None:
                 raise ValidationError(
                     "Active and Confirmed projects must have at least 1 funding source."
                 )
+            else:
+                if not self.funding_source.exists() or not all(
+                    [f.is_complete() for f in self.funding_source.all()]
+                ):
+                    raise ValidationError(
+                        "Funding of Active and Confirmed projects must be complete."
+                    )
 
-            if not all([f.is_complete() for f in self.funding_source.all()]):
-                raise ValidationError(
-                    "Funding of Active and Confirmed projects must be complete."
-                )
+        if self.pk is not None and self.status == "Active":
+            was_active = Project.objects.filter(pk=self.pk, status="Active").exists()
+            if not was_active and self.has_warnings:
+                message = "A project cannot be made 'Active' if there are warnings:"
+                raise ValidationError([message, *self.warnings])
 
     @property
     def weeks_to_deadline(self) -> tuple[int, float] | None:

--- a/tests/main/test_models.py
+++ b/tests/main/test_models.py
@@ -138,7 +138,7 @@ class TestProject:
         )
         # Now there should be no warnings anymore.
         assert project.has_warnings is False
-        
+
         # Test passes when trying to set it to 'Active' now that
         # both funding and phase are enabled
         project.clean()

--- a/tests/main/test_models.py
+++ b/tests/main/test_models.py
@@ -94,15 +94,21 @@ class TestProject:
         )
         project.clean()
 
-        # Change to active but no pk value
+        # Change to active but no pk value (project not saved yet)
         project.status = "Active"
-        project.clean()
-
-        # No funding, no active
-        project.save()
         with pytest.raises(
             ValidationError,
             match=r"Active and Confirmed projects must have at least 1 funding source.",
+        ):
+            project.clean()
+
+        # No funding, no active
+        project.save()
+        # pk value now exists, so the error changes too if funding not available
+        # or row in table is incomplete
+        with pytest.raises(
+            ValidationError,
+            match=r"Funding of Active and Confirmed projects must be complete.",
         ):
             project.clean()
 

--- a/tests/main/test_models.py
+++ b/tests/main/test_models.py
@@ -136,12 +136,11 @@ class TestProject:
             start_date=project.start_date,
             end_date=project.end_date,
         )
+        # Now there should be no warnings anymore.
+        assert project.has_warnings is False
+        
         # Test passes when trying to set it to 'Active' now that
         # both funding and phase are enabled
-        project.status = "Active"
-        # If the code changes and unexpected warnings are raised, the test will fail
-        # here before moving onto `project.clean()`
-        assert project.has_warnings is False
         project.clean()
 
     @pytest.mark.parametrize(

--- a/tests/main/test_models.py
+++ b/tests/main/test_models.py
@@ -99,7 +99,7 @@ class TestProject:
         with pytest.raises(ValidationError, match="cannot be created directly in"):
             project.clean()
 
-        # Set to 'Tentative' and save in memory so that `was_active == FALSE` as
+        # Set to 'Tentative' and save in database so that `was_active == FALSE` as
         # per the new changes in `clean()`
         project.status = "Tentative"
         project.save()

--- a/tests/main/test_models.py
+++ b/tests/main/test_models.py
@@ -94,21 +94,21 @@ class TestProject:
         )
         project.clean()
 
-        # Change to active but no pk value (project not saved yet)
+        # Change to 'Active' but pK is None (status not saved yet, cannot create)
+        project.status = "Active"
+        with pytest.raises(ValidationError, match="cannot be created directly in"):
+            project.clean()
+
+        # Set to 'Tentative' and save in memory so that `was_active == FALSE` as
+        # per the new changes in `clean()`
+        project.status = "Tentative"
+        project.save()
+        # When trying yo update it to 'Active', there will be no funding
+        # and an error should occur
         project.status = "Active"
         with pytest.raises(
             ValidationError,
-            match=r"Active and Confirmed projects must have at least 1 funding source.",
-        ):
-            project.clean()
-
-        # No funding, no active
-        project.save()
-        # pk value now exists, so the error changes too if funding not available
-        # or row in table is incomplete
-        with pytest.raises(
-            ValidationError,
-            match=r"Funding of Active and Confirmed projects must be complete.",
+            match="cannot be made Active or Confirmed if",
         ):
             project.clean()
 
@@ -120,13 +120,28 @@ class TestProject:
         )
         with pytest.raises(
             ValidationError,
-            match=r"Funding of Active and Confirmed projects must be complete.",
+            match="cannot be made Active or Confirmed if",
         ):
             project.clean()
 
-        # Now things work, as the above is enough for an internal source to be complete
+        # Adding `funding.source` is not enough with new restrictions to when
+        # projects can become 'Active': there must be at least one phase to
+        # change the status of a project to 'Active'
         funding.source = "Internal"
         funding.save()
+        # Add phase
+        models.ProjectPhase.objects.create(
+            project=project,
+            value=1,
+            start_date=project.start_date,
+            end_date=project.end_date,
+        )
+        # Test passes when trying to set it to 'Active' now that
+        # both funding and phase are enabled
+        project.status = "Active"
+        # If the code changes and unexpected warnings are raised, the test will fail
+        # here before moving onto `project.clean()`
+        assert project.has_warnings is False
         project.clean()
 
     @pytest.mark.parametrize(

--- a/tests/main/test_models_utils.py
+++ b/tests/main/test_models_utils.py
@@ -38,8 +38,10 @@ class TestProjectWarnings:
             start_date=timezone.now().date(),
             end_date=timezone.now().date() + timedelta(days=42),
         )
-
-        assert project.warnings == ["No funding defined for the project."]
+        # `_warn_no_funding` checks for both now, message changed
+        assert project.warnings == [
+            "No funding defined for the project or incomplete row."
+        ]
         assert project.has_warnings
 
     def test_warn_phase_lifetime(self, project_static, phase):

--- a/tests/main/test_views.py
+++ b/tests/main/test_views.py
@@ -357,7 +357,7 @@ class TestProjectCreateView(PermissionRequiredMixin, TemplateOkMixin):
         # 200 is expected, nothing should be found in the db
         assert not Project.objects.filter(name="Should Fail").exists()
         # Check that the expected error is shown to the user
-        assert b"at least 1 funding source" in response.content
+        assert b"Projects cannot be created directly in" in response.content
 
 
 @pytest.mark.usefixtures("project")

--- a/tests/main/test_views.py
+++ b/tests/main/test_views.py
@@ -310,7 +310,8 @@ class TestProjectCreateView(PermissionRequiredMixin, TemplateOkMixin):
             "lead": user.pk,
             "start_date": timezone.now().date(),
             "end_date": timezone.now().date() + timedelta(days=42),
-            "status": "Active",
+            # Use 'Tentative' as 'Active' projects cannot be created without funding
+            "status": "Tentative",
             "charging": "Actual",
         }
 
@@ -334,6 +335,29 @@ class TestProjectCreateView(PermissionRequiredMixin, TemplateOkMixin):
         assert response.status_code == HTTPStatus.OK
         projects = response.context["project_list"].values("name")[0]
         assert "Project 123" in projects["name"]
+
+    def test_post_active_without_funding_rejected(self, admin_client, department, user):
+        """Creating a project directly as 'Active' (no funding) must not be possible."""
+        data = {
+            "name": "Should Fail",
+            "nature": "Support",
+            "pi": "John Smith",
+            "department": department.pk,
+            "lead": user.pk,
+            "start_date": timezone.now().date(),
+            "end_date": timezone.now().date() + timedelta(days=42),
+            "status": "Active",
+            "charging": "Actual",
+        }
+
+        # Simulate admin logs in and tries to create form defined in `data`
+        response = admin_client.post("/projects/create/", data)
+        # Form is now invalid, post should not be saved
+        assert response.status_code == HTTPStatus.OK
+        # 200 is expected, nothing should be found in the db
+        assert not Project.objects.filter(name="Should Fail").exists()
+        # Check that the expected error is shown to the user
+        assert b"at least 1 funding source" in response.content
 
 
 @pytest.mark.usefixtures("project")


### PR DESCRIPTION
# Description

Projects that already existed (e.g., 'Tentative') should not be allowed to become 'Active' if there are warnings. In addition, projects that are yet to be created should not be allowed to be labelled as 'Active' (funding cannot be input at this stage, which should trigger an error when trying to create this project).

Issues addressed:

* Issue #726 
* Issue #466 

## Notes

* The fix for [issue #466](https://github.com/ImperialCollegeLondon/proCAT/issues/466) is redundant when checking whether the funding source is available if the code suggested in [issue #726](https://github.com/ImperialCollegeLondon/proCAT/issues/726) is implemented. Nevertheless, the proposed fix would work for other warnings.

* Tests `TestProject::test_clean_when_project_active`  and `TestProjectCreateView::test_post` have been modified to match current fixes:

  https://github.com/ImperialCollegeLondon/proCAT/blob/3c2e2ce5ec2506ddb5f7469803a5cc24a5920a1c/tests/main/test_models.py#L82

  https://github.com/ImperialCollegeLondon/proCAT/blob/3c2e2ce5ec2506ddb5f7469803a5cc24a5920a1c/tests/main/test_views.py#L303

* A new test has been added in [`tests_views.py`](https://github.com/ImperialCollegeLondon/proCAT/blob/main/tests/main/test_views.py) to check that no new projects can start labelled as 'Active':

  ```py
  def test_post_active_without_funding_rejected(self, admin_client, department, user):
          """Creating a project directly as 'Active' (no funding) must not be possible."""
          data = {
              "name": "Should Fail",
              "nature": "Support",
              "pi": "John Smith",
              "department": department.pk,
              "lead": user.pk,
              "start_date": timezone.now().date(),
              "end_date": timezone.now().date() + timedelta(days=42),
              "status": "Active",
              "charging": "Actual",
          }
  
          # Simulate admin logs in and tries to create form defined in `data`
          response = admin_client.post("/projects/create/", data)
          # Form is now invalid, post should not be saved
          assert response.status_code == HTTPStatus.OK
          # 200 is expected, nothing should be found in the db
          assert not Project.objects.filter(name="Should Fail").exists()
          # Check that the expected error is shown to the user
          assert b"at least 1 funding source" in response.content
   ```

## Type of change

- [ ] Documentation (non-breaking change that adds or improves the documentation)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Optimization (non-breaking, back-end change that speeds up the code)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (whatever its nature)

## Key checklist

- [x] All tests pass (eg. `python -m pytest`)
- [ ] The documentation builds and looks OK (eg. `mkdocs serve`)
- [x] Pre-commit hooks run successfully (eg. `pre-commit run --all-files`)

## Further checks

- [x] Code is commented, particularly in hard-to-understand areas
- [x] Tests added or an issue has been opened to tackle that in the future (i.e., tests address both issues #726 and #466)